### PR TITLE
Alpha miner revisit

### DIFF
--- a/pmkoalas/conformance/tokenreplay.py
+++ b/pmkoalas/conformance/tokenreplay.py
@@ -3,13 +3,13 @@ This module focuses on providing ways to produce a log from models in the class
 of Petri nets.
 """
 from copy import deepcopy
-from typing import Dict, Iterable, Mapping,Set,List
+from typing import Dict, Iterable, Mapping,Set,List,Tuple
 
 from pmkoalas import __version__
 from pmkoalas.complex import ComplexEventLog, ComplexTrace, ComplexEvent
-from pmkoalas.simple import Trace
+from pmkoalas.simple import Trace, EventLog
 from pmkoalas.models.transitiontree import TransitionTreeGuard
-from pmkoalas._logging import info, InfoQueueProcessor, InfoIteratorProcessor
+from pmkoalas._logging import info, debug, InfoQueueProcessor, InfoIteratorProcessor
 
 #typing imports
 from typing import TYPE_CHECKING
@@ -92,7 +92,23 @@ class PetriNetMarking():
             next_mark[outcoming] = next_mark[outcoming] + 1
         return PetriNetMarking(self._net, next_mark)
     
+    def contains(self, place:'Place') -> bool:
+        """
+        Returns true if the given place is in the marking.
+        """
+        return self._mark[place] > 0
+    
+    def reached_final(self) -> bool:
+        """
+        Returns true if the marking is the final marking of the net.
+        """
+        return self == self._net.final_marking
+    
     # data-model functions
+    def __str__(self) -> str:
+        vals = [ (i,v) for i,v in self._mark.items() if v > 0 ]
+        return str(vals)
+    
     def __eq__(self, other: object) -> bool:
         if (isinstance(other, PetriNetMarking)):
             return self._mark == other._mark
@@ -221,6 +237,47 @@ class PlayoutTrace(ComplexTrace):
         Returns the guard of the i-th step.
         """
         return self[i].guard
+    
+def generate_traces_from_lpn(
+        model:'LabelledPetriNet', max_length:int,
+        strict:bool=False, updates_on:int=1000) \
+    -> EventLog:
+    """
+    Generates a simple log of a sample traces from a model with a length 
+    of max_length. By default returns traces that did not reach the final
+    marking. If strict is set to True, only traces that reach the final
+    marking are returned.
+    """
+    inprogress:List[Tuple[Trace,PetriNetMarking]] = [ 
+        (Trace([]), deepcopy(model.initial_marking)) ]
+    completed = []
+    pcount = 0
+    while len(inprogress) > 0:
+        trace, mark = inprogress.pop(0)
+        debug(f"processing trace {str(trace)} with marking {str(mark)}")
+        if len(trace) == max_length:
+            if strict:
+                if mark.reached_final():
+                    completed.append(trace)
+            else:
+                completed.append(trace)
+        else:
+            if mark.reached_final():
+                completed.append(trace)
+            else:
+                firable = mark.can_fire()
+                for t in firable:
+                    new_mark = mark.remark(t)
+                    new_trace = Trace(trace.sequence + [t.name])
+                    inprogress.append((new_trace, new_mark))
+        pcount += 1
+        if (pcount % updates_on == 0):
+            info(f"processing {len(inprogress)} partial executions of the lpn")
+            info(f"shortest trace :: {len(inprogress[0][0])}")
+            info(f"longest trace :: {len(inprogress[-1][0])}")
+            pcount = 0
+    return EventLog(completed, f"Generated traces from LPN ({model.name})")
+
 
 def construct_playout_log(model:'PetriNetWithData', max_length:int, 
         initial_marking:'PetriNetMarking', final_marking:'PetriNetMarking') \

--- a/pmkoalas/conformance/tokenreplay.py
+++ b/pmkoalas/conformance/tokenreplay.py
@@ -96,7 +96,9 @@ class PetriNetMarking():
         """
         Returns true if the given place is in the marking.
         """
-        return self._mark[place] > 0
+        if (place not in self._mark.keys()):
+            return self._mark[place] > 0
+        return False
     
     def is_subset(self, other:'PetriNetMarking') -> bool:
         """
@@ -114,6 +116,11 @@ class PetriNetMarking():
         return self == self._net.final_marking
     
     # data-model functions
+    def __getitem__(self, place:'Place') -> int:
+        if (self.contains(place)):
+            return self._mark[place]
+        return 0
+
     def __str__(self) -> str:
         vals = [ (i,v) for i,v in self._mark.items() if v > 0 ]
         return str(vals)

--- a/pmkoalas/conformance/tokenreplay.py
+++ b/pmkoalas/conformance/tokenreplay.py
@@ -96,7 +96,7 @@ class PetriNetMarking():
         """
         Returns true if the given place is in the marking.
         """
-        if (place not in self._mark.keys()):
+        if (place in self._mark.keys()):
             return self._mark[place] > 0
         return False
     

--- a/pmkoalas/discovery/alpha_miner.py
+++ b/pmkoalas/discovery/alpha_miner.py
@@ -15,7 +15,7 @@ from copy import deepcopy,copy
 from pmkoalas.simple import EventLog
 from pmkoalas._logging import info,debug
 from pmkoalas.directly import DirectlyFollowPair
-from pmkoalas.models.petrinet import LabelledPetriNet
+from pmkoalas.models.petrinet import LabelledPetriNet, Arc
 from pmkoalas.discovery.meta import DiscoveryTechnique
 
 class AlphaRelationType(Enum):

--- a/pmkoalas/discovery/alpha_miner.py
+++ b/pmkoalas/discovery/alpha_miner.py
@@ -407,7 +407,7 @@ class AlphaMinerInstance(DiscoveryTechnique):
             places[place.name] = Place(place.name)
         for transition in TL:
             transitions[transition.name] = Transition(transition.name)
-        return LabelledPetriNet(
+        net = LabelledPetriNet(
             places.values(), transitions.values(),
             [Arc(
                 places[f.src.name] if 
@@ -418,6 +418,26 @@ class AlphaMinerInstance(DiscoveryTechnique):
                 else transitions[f.tar.name],
             )
             for f in FL])
+        imark = {}
+        fmark = {}
+        for place in net.places:
+            inc_arcs = set(
+                arc 
+                for arc in net.arcs 
+                if arc.to_node == place
+            )
+            out_arcs = set(
+                arc 
+                for arc in net.arcs 
+                if arc.from_node == place
+            )
+            if len(inc_arcs) == 0:
+                imark[place] = 1
+            if len(out_arcs) == 0:
+                fmark[place] = 1
+        net.set_initial_marking(imark)
+        net.set_final_marking(fmark)
+        return net
 
     def _step_one(self, log:EventLog) -> Set[str]:
         """
@@ -580,4 +600,308 @@ class AlphaMinerInstance(DiscoveryTechnique):
                     ))
         return flows
 
+### ------------------- Alpha Miner Plus ------------------- ###
+
+class AlphaPlusRelation(AlphaRelation):
+    """
+    A helper class to determine the ordering relations that captures
+    length-two loops.
+
+    Follows the work of the following article: Alves De Medeiros, A. K., 
+    Dongen, van, B. F., Aalst, van der, W. M. P., & Weijters, A. J. M. M. 
+    (2004). Process mining : extending the alpha-algorithm to mine short 
+    loops.
+
+    The ordering relations are described in Defintion 3.3. of the article.
+    """
+
+    def __init__(self, src: str, target: str, follows: List[Tuple[str]] = None) -> None:
+        super().__init__(src, target, follows)
+        self._two_step_follows = set()
     
+    def add_two_step_follows(self, src: str, follow: str) -> None:
+        if (src in self._AlphaRelation__members):
+            self._two_step_follows.add((src, follow))
+
+    def relation(self) -> AlphaRelationType:
+        # check for length two loop relations e.g. aba or bab 
+        # check for ab-? then check for aba 
+        loop_delta_a = False
+        if ((self.src,self.target) in self._follows):
+            if (self.target,self.src) in self._two_step_follows:
+                loop_delta_a = True
+        # check for ba-? then check for bab 
+        loop_delta_b = False
+        if ((self.target,self.src) in self._follows):
+            if (self.src,self.target) in self._two_step_follows:
+                loop_delta_b = True
+        
+        looping = loop_delta_b and loop_delta_a
+        # return one of the original alpha relations
+        if ((self.src,self.target) in self._follows and 
+            (self.target,self.src) in self._follows and
+            not looping
+        ):
+            return AlphaRelationType.PD 
+        elif ((self.src,self.target) in self._follows and 
+              (
+                    (self.target,self.src) not in self._follows
+                    or 
+                    looping
+             )
+        ):
+            return AlphaRelationType.CD 
+        elif ( (self.src,self.target) in self._follows):
+            return AlphaRelationType.DF
+        return AlphaRelationType.NF
+
+class AlphaMinerPlusInstance(DiscoveryTechnique):
+    """
+    Mines a Petri net using the alpha miner plus algorithm as presented in
+    Alves De Medeiros, A. K., 
+    Dongen, van, B. F., Aalst, van der, W. M. P., & Weijters, A. J. M. M. 
+    (2004). Process mining : extending the alpha-algorithm to mine short 
+    loops.
+
+    The alpha miner plus algorithm is an extension of the alpha miner,
+    whereby preprocessing the given log and adjusting the ordering relations
+    the alpha-plus miner can mine petri nets with short loops.
+    """
+
+    def __init__(self, min_inst:int=1 ,optimised:bool=False) -> None:
+        super().__init__()
+        self._opt = optimised
+        self._min_inst = min_inst
+
+    def mine_footprint_matrix(self, log:EventLog) -> Dict[
+        str,Dict[str,AlphaPlusRelation]]:
+        """
+        Mines the footprint matrix of the alpha miner relations
+        between process activities.
+        """
+        info("Mining footprint matrix...")
+        self._matrix = dict()
+        TL = self._step_one(log)
+        # set up matrix 
+        for src in TL:
+            self._matrix[src] = dict()
+            for target in TL:
+                self._matrix[src][target] = AlphaPlusRelation(
+                    src=src,target=target
+                )
+        # find directly flows lang
+        flang = log.directly_follow_relations()
+        # update relations
+        for col in self._matrix.values():
+            for relation in col.values():
+                src = relation.src
+                target = relation.target
+                # test flow relation from src to target
+                pair = DirectlyFollowPair(src, target, 1)
+                if (flang.contains(pair)):
+                    fpair = flang.find(pair)
+                    if fpair.frequency() >= self._min_inst:
+                        # print(f"adding follows ({src},{target}) to {relation}")
+                        relation.add_follows(src, target)
+                        # check for aba in proceeding
+                        if src in fpair.proceeding():
+                            relation.add_two_step_follows(src, target)
+                # test flow relation from target to src
+                pair = DirectlyFollowPair(target, src, 1)
+                if (flang.contains(pair)):
+                    fpair = flang.find(pair)
+                    if fpair.frequency() >= self._min_inst:
+                        # print(f"adding follows ({target},{src}) to {relation}")
+                        relation.add_follows(target, src)
+                        # check for bab in proceeding
+                        if target in fpair.proceeding():
+                            relation.add_two_step_follows(target, src)
+        # make new copy
+        out = dict()
+        for src in TL:
+            out[src] = deepcopy(self._matrix[src])
+        info("Footprint matrix mined.")
+        return deepcopy(self._matrix)
+    
+    def discover(self, log:EventLog) -> LabelledPetriNet:
+        """
+        Computes a Petri net to represent the given event log, assuming that
+        the event log is a loop-complete workflow log (def 3.1.).
+
+        The algorithm consists of nine steps where the alpha miner alogrithm
+        is called but mines ordering relations that capture length-two loops,
+        as described in Def. 4.4 of the article.
+        """
+        from pmkoalas.models.petrinet import Transition,Arc, Place
+        self._matrix = None
+        _ = self.mine_footprint_matrix(log)
+        #step one 
+        acts = self._step_one(log)
+        #step two 
+        doubles = self._step_two(log)
+        #step three 
+        nots = self._step_three(acts, doubles)
+        #step four 
+        fdoubles = self._step_four(doubles, nots)
+        #step five
+        wlog = self._step_five(log, doubles)
+        #step six
+        net = self._step_six(wlog)
+        # return net 
+        places = net.places 
+        transitions = net.transitions
+        ntransitions = set()
+        # the ids of the places need to match with the transitions
+        # for fun downstream stuff...
+        swaps = dict()
+        missing = set()
+        for f in fdoubles:
+            if isinstance(f.from_node,Place) and f.from_node.name not in swaps:
+                options = set( 
+                    p 
+                    for p in places 
+                    if p.name == f.from_node.name
+                )
+                if (len(options) > 0):
+                    swaps[f.from_node.name] = options.pop()
+                else:
+                    missing.add(f.from_node)
+            elif isinstance(f.from_node, Transition):
+                ntransitions.add(
+                    f.from_node
+                )
+            if isinstance(f.to_node,Place) and f.to_node not in swaps:
+                options = set( 
+                    p 
+                    for p in places 
+                    if p.name == f.to_node.name
+                )
+                if (len(options) > 0):
+                    swaps[f.to_node.name] = options.pop()
+                else:
+                    missing.add(f.to_node)
+            elif isinstance(f.to_node, Transition):
+                ntransitions.add(
+                    f.to_node
+                )
+        nfdoubles = set()
+        for f in fdoubles:
+            nfdoubles.add(
+                Arc(
+                    swaps[f.from_node.name] if f.from_node.name in swaps.keys() 
+                    else f.from_node,
+                    swaps[f.to_node.name] if f.to_node.name in swaps.keys()
+                    else f.to_node
+                )
+            )
+        # now we union the flows
+        transitions = transitions.union(ntransitions)
+        flows = net.arcs.union(nfdoubles)
+        places = places.union(missing)
+        net = LabelledPetriNet(
+            places, transitions, flows
+        )
+        imark = {}
+        fmark = {}
+        for place in net.places:
+            inc_arcs = set(
+                arc 
+                for arc in net.arcs 
+                if arc.to_node == place
+            )
+            out_arcs = set(
+                arc 
+                for arc in net.arcs 
+                if arc.from_node == place
+            )
+            if len(inc_arcs) == 0:
+                imark[place] = 1
+            if len(out_arcs) == 0:
+                fmark[place] = 1
+        net.set_initial_marking(imark)
+        net.set_final_marking(fmark)
+        return net 
+    
+    def _step_one(self, log:EventLog) -> Set[str]:
+        """
+        Returns a set of all process activities seen in the 
+        event log.
+        """
+        return log.seen_activities()
+    
+    def _step_two(self, log:EventLog) -> Set[str]:
+        """
+        Returns a set of process activities seen in the event, such that there
+        exists a trace in the log where ...aa... is seen.
+        """
+        doubles = set()
+        for trace in log.language():
+            for i in range(1,len(trace)):
+                if (trace[i-1] == trace[i]):
+                    doubles.add(trace[i])
+        return doubles
+    
+    def _step_three(self, acts: Set[str], doubles: Set[str]) -> Set[str]:
+        """
+        Simply returns the set of activities that are not in one-length loops.
+        """
+        return acts.difference(doubles)
+    
+    def _step_four(self, doubles:Set[str], nots: set[str]) -> Set['Arc']:
+        """
+        Returns a set of flow relations that capture the ordering relations
+        that capture length-one loops.
+        """
+        from pmkoalas.models.petrinet import Place,Transition,Arc
+        flows = set()
+        for t in doubles:
+            places_A = set(
+                a 
+                for a in nots 
+                if self._matrix[a][t].relation() == AlphaRelationType.CD
+            )
+            places_B = set(
+                b 
+                for b in nots 
+                if self._matrix[t][b].relation() == AlphaRelationType.CD
+            )
+            trans = Transition(t)
+            if len(places_A) == 0 and len(places_B) == 0:
+                place = AlphaStartPlace()
+            else:
+                pair = AlphaPair(places_A.difference(places_B), 
+                                places_B.difference(places_A)
+                )
+                place = AlphaPlace(str(pair), pair.left, pair.right)
+            place = Place(place.name)
+            flows.add(Arc(trans, place))
+            flows.add(Arc(place, trans))
+        return flows
+    
+    def _step_five(self, log:EventLog, doubles: set[str]) -> EventLog:
+        """
+        Returns a new event log where all traces have been processed to remove
+        activities that were identified in one-length loops.
+        """
+        from pmkoalas.simple import Trace
+        new_traces = []
+        for trace, freq in log.__iter__():
+            new_trace = []
+            for act in trace:
+                if act not in doubles:
+                    new_trace.append(act)
+            for i in range(freq):
+                new_traces.append(Trace(new_trace))
+        return EventLog(new_traces)
+    
+    def _step_six(self, log:EventLog) -> LabelledPetriNet:
+        """
+        Returns the Petri net discovered by the alpha miner using the alpha
+        plus relations.
+        """
+        miner = AlphaMinerInstance(min_inst=self._min_inst,optimised=self._opt)
+        miner.mine_footprint_matrix = self.mine_footprint_matrix
+        return miner.discover(log)
+        
+    
+

--- a/pmkoalas/models/dotutil.py
+++ b/pmkoalas/models/dotutil.py
@@ -4,8 +4,10 @@ import shutil
 import subprocess
 import tempfile
 from logging import info
+from typing import Dict
+from warnings import warn
 
-from pmkoalas.models.petrinet import LabelledPetriNet
+from pmkoalas.models.petrinet import LabelledPetriNet,Place
 
 DFENC='utf-8'
 
@@ -25,36 +27,79 @@ def export_DOT_to_image(vard:str,oname:str,dotStr:str,outformat:str='png'):
     info(f"Generating diagram {oname} ... ")
     dot_to_img(dotStr,dotf,imgpnf,outformat)
 
+
+# colour scheme for lpns
+START_PLACE_COLOUR = "#c5e1a5"
+FINAL_PLACE_COLOUR = "#ef9a9a"
+PLACE_COLOUR = "#ffe0b2"
+TRANSITION_COLOUR = "#81c784"
+ARC_COLOUR = "#263238"
+BACKWARDS_COLOUR = "gray"
+FONT_COLOUR = "black"
+
+def prettier_handler_place(p:Place, lpn:LabelledPetriNet, nodeId) -> str:
+    ret = ""
+    label = '<'+'<BR/>'.join([p.name[i:i+16] for i in range(0, len(p.name), 16)])+">"
+    if lpn.initial_marking is not None and lpn.initial_marking.contains(p):
+        ret += f"\t\t{nodeId}[label={label},fillcolor=\"{START_PLACE_COLOUR}\"];"
+    elif lpn.final_marking is not None and lpn.final_marking.contains(p):
+        ret += f"\t\t{nodeId}[label={label},fillcolor=\"{FINAL_PLACE_COLOUR}\"];"
+    else:
+        ret += f"\t\t{nodeId}[label={label}];"
+    ret += "\n"
+    return ret
+
 def lpn_prettier_dot(lpn:LabelledPetriNet):
-    ret = "digraph{"
-    ret += "dpi=150;rankdir=LR;nodesep=0.6;ranksep=0.3;"
-    ret += "edge[penwidth=4,fontsize=16,minlen=2,fontname=\"roboto\"];"
+    ret = "digraph{\n"
+    ret += "\tdpi=150;rankdir=LR;nodesep=0.6;ranksep=0.3;\n"
+    ret += "\tedge[penwidth=4,fontsize=16,minlen=2,fontname=\"roboto\"];\n"
     nodeIds = dict()
     nid = 0
-    ret += "{"
-    ret += "node[shape=circle,margin=\"0.05, 0.05\",fillcolor=lightgray,style=filled,width=1,penwidth=2,fontsize=9,fontname=\"roboto\"];"
-    for v in lpn.places:
-        nodeIds[v.nodeId] = f"n{nid}"
-        label = '<'+'<BR/>'.join([v.name[i:i+16] for i in range(0, len(v.name), 16)])+">"
-        ret += f"{nodeIds[v.nodeId]}[label={label}];"
-        nid += 1
-    assert nid == len(lpn.places)
-    ret += "}"
-    ret += "{"
-    ret += "node[shape=box,style=\"rounded\",width=2,penwidth=3,fontsize=18,fontname=\"roboto\",margin=\"0, 0.2\"];"
-    for t in lpn.transitions:
-        nodeIds[t.nodeId] = f"n{nid}"
-        label = '<'+'<BR/>'.join([t.name[i:i+16] for i in range(0, len(t.name), 16)])+">"
-        ret += f"{nodeIds[t.nodeId]}[label={label}];"
-        nid += 1
-    assert nid == len(lpn.places) + len(lpn.transitions)
-    ret += "}"
-    elabel = 0
-    seen = set()
-    for a in lpn.arcs:
-        ret += f"{nodeIds[a.from_node.nodeId]} -> {nodeIds[a.to_node.nodeId]}[arrowhead=normal,color=gray];"
-        elabel += 1
-    ret += "}"
+    # here is where I would write a walking algorithm
+    # but I am not ready to do that...
+    if (False):
+        # walks places (if marking is set)
+        walked_places = []
+        walked_transitions = []
+        seen = set()
+        ret += "\t{\n"
+        ret += f"\t\tnode[shape=circle,margin=\"0.05, 0.05\",fillcolor=\"{PLACE_COLOUR}\",style=filled,width=1,penwidth=2,fontsize=9,fontname=\"roboto\"];\n" 
+        # handle places
+    else:
+        ret += "\t{\n"
+        ret += f"\t\tnode[shape=circle,margin=\"0.05, 0.05\",fillcolor=\"{PLACE_COLOUR}\",style=filled,width=1,penwidth=2,fontsize=9,fontname=\"roboto\"];\n"
+        for v in lpn.places:
+            nodeIds[v.nodeId] = f"n{nid}"
+            ret += prettier_handler_place(v, lpn, nodeIds[v.nodeId])
+            nid += 1
+        assert nid == len(lpn.places)
+        ret += "\t}\n"
+        ret += "\t{\n"
+        ret += f"\t\tnode[shape=box,style=\"rounded,filled\",fillcolor=\"{TRANSITION_COLOUR}\",width=2,penwidth=3,fontsize=18,fontname=\"roboto\",margin=\"0, 0.2\"];\n"
+        for t in lpn.transitions:
+            nodeIds[t.nodeId] = f"n{nid}"
+            label = '<'+'<BR/>'.join([t.name[i:i+16] for i in range(0, len(t.name), 16)])+">"
+            ret += f"\t\t{nodeIds[t.nodeId]}[label={label}];\n"
+            nid += 1
+        assert nid == len(lpn.places) + len(lpn.transitions)
+        ret += "\t}\n"
+        elabel = 0
+        for a in lpn.arcs:
+            if a.from_node.nodeId in nodeIds:
+                dotNode_from = nodeIds[a.from_node.nodeId]
+            else:
+                warn(f"Node {a.from_node} not found in nodeIds, likely something is wrong with the given LPN")
+                dotNode_from = f"n{nid}"
+                nid += 1
+            if a.to_node.nodeId in nodeIds:
+                dotNode_to = nodeIds[a.to_node.nodeId]
+            else:
+                warn(f"Node {a.to_node} not found in nodeIds, likely something is wrong with the given LPN")
+                dotNode_to = f"n{nid}"
+                nid += 1
+            ret += f"\t{dotNode_from} -> {dotNode_to}[arrowhead=normal,color=\"{ARC_COLOUR}\"];\n"
+            elabel += 1
+        ret += "}"
     # assert elabel == len(lpn.arcs)
     return ret
 

--- a/pmkoalas/models/dotutil.py
+++ b/pmkoalas/models/dotutil.py
@@ -33,6 +33,7 @@ START_PLACE_COLOUR = "#c5e1a5"
 FINAL_PLACE_COLOUR = "#ef9a9a"
 PLACE_COLOUR = "#ffe0b2"
 TRANSITION_COLOUR = "#81c784"
+TAU_COLUR = "lightgray"
 ARC_COLOUR = "#263238"
 BACKWARDS_COLOUR = "gray"
 FONT_COLOUR = "black"
@@ -78,8 +79,11 @@ def lpn_prettier_dot(lpn:LabelledPetriNet):
         ret += f"\t\tnode[shape=box,style=\"rounded,filled\",fillcolor=\"{TRANSITION_COLOUR}\",width=2,penwidth=3,fontsize=18,fontname=\"roboto\",margin=\"0, 0.2\"];\n"
         for t in lpn.transitions:
             nodeIds[t.nodeId] = f"n{nid}"
-            label = '<'+'<BR/>'.join([t.name[i:i+16] for i in range(0, len(t.name), 16)])+">"
-            ret += f"\t\t{nodeIds[t.nodeId]}[label={label}];\n"
+            if (t.silent):
+                ret += f"\t\t{nodeIds[t.nodeId]}[xlabel={t.name}, fillcolor=\"{TAU_COLUR}\", width=\"0.25\", height=1, margin=0, label=\"\"];\n" 
+            else:
+                label = '<'+'<BR/>'.join([t.name[i:i+12] for i in range(0, len(t.name), 12)])+">"
+                ret += f"\t\t{nodeIds[t.nodeId]}[label={label}];\n"
             nid += 1
         assert nid == len(lpn.places) + len(lpn.transitions)
         ret += "\t}\n"

--- a/pmkoalas/models/dotutil.py
+++ b/pmkoalas/models/dotutil.py
@@ -5,6 +5,8 @@ import subprocess
 import tempfile
 from logging import info
 
+from pmkoalas.models.petrinet import LabelledPetriNet
+
 DFENC='utf-8'
 
 def dot_to_img(dot:str,dotf:str,imgf:str,outformat:str,dfenc:str=DFENC):
@@ -22,5 +24,38 @@ def export_DOT_to_image(vard:str,oname:str,dotStr:str,outformat:str='png'):
     imgpnf = os.path.join(vard,oname+'_pn.' + outformat)
     info(f"Generating diagram {oname} ... ")
     dot_to_img(dotStr,dotf,imgpnf,outformat)
+
+def lpn_prettier_dot(lpn:LabelledPetriNet):
+    ret = "digraph{"
+    ret += "dpi=150;rankdir=LR;nodesep=0.6;ranksep=0.3;"
+    ret += "edge[penwidth=4,fontsize=16,minlen=2,fontname=\"roboto\"];"
+    nodeIds = dict()
+    nid = 0
+    ret += "{"
+    ret += "node[shape=circle,margin=\"0.05, 0.05\",fillcolor=lightgray,style=filled,width=1,penwidth=2,fontsize=9,fontname=\"roboto\"];"
+    for v in lpn.places:
+        nodeIds[v.nodeId] = f"n{nid}"
+        label = '<'+'<BR/>'.join([v.name[i:i+16] for i in range(0, len(v.name), 16)])+">"
+        ret += f"{nodeIds[v.nodeId]}[label={label}];"
+        nid += 1
+    assert nid == len(lpn.places)
+    ret += "}"
+    ret += "{"
+    ret += "node[shape=box,style=\"rounded\",width=2,penwidth=3,fontsize=18,fontname=\"roboto\",margin=\"0, 0.2\"];"
+    for t in lpn.transitions:
+        nodeIds[t.nodeId] = f"n{nid}"
+        label = '<'+'<BR/>'.join([t.name[i:i+16] for i in range(0, len(t.name), 16)])+">"
+        ret += f"{nodeIds[t.nodeId]}[label={label}];"
+        nid += 1
+    assert nid == len(lpn.places) + len(lpn.transitions)
+    ret += "}"
+    elabel = 0
+    seen = set()
+    for a in lpn.arcs:
+        ret += f"{nodeIds[a.from_node.nodeId]} -> {nodeIds[a.to_node.nodeId]}[arrowhead=normal,color=gray];"
+        elabel += 1
+    ret += "}"
+    # assert elabel == len(lpn.arcs)
+    return ret
 
 

--- a/pmkoalas/models/petrinet.py
+++ b/pmkoalas/models/petrinet.py
@@ -576,6 +576,9 @@ def convert_net_to_xml(net:LabelledPetriNet,
         if isinstance(tran, GuardedTransition):
             attribs['guard'] = str(tran.guard)
             attributes_for_guards.update(tran.guard.variables())
+        # check for silent
+        if tran.silent:
+            attribs['invisible'] = "true"
         # make a transition
         tranNode = ET.SubElement(page,'transition', 
                         attrib=attribs )

--- a/pmkoalas/models/petrinet.py
+++ b/pmkoalas/models/petrinet.py
@@ -663,7 +663,8 @@ def export_net_to_pnml(
     ET.indent( xml ) 
     ET.ElementTree(xml).write(fname,xml_declaration=True, encoding="utf-8")
 
-def parse_pnml_into_lpn(filepath:str) -> LabelledPetriNet:
+def parse_pnml_into_lpn(filepath:str,
+        use_localnode_id:bool=True) -> LabelledPetriNet:
     """
     Constructs a labelled Petri net from the given filepath to a pnml file.
     """
@@ -695,7 +696,7 @@ def parse_pnml_into_lpn(filepath:str) -> LabelledPetriNet:
                 lid = tools.attrib["localNodeID"]
         id = place.attrib["id"]
         # making a place
-        pid = lid if lid != None else id
+        pid = lid if lid != None and use_localnode_id else id
         place_ids[id] = pid
         parsed = Place( place.find("name").find("text").text, pid)
         places[pid] = parsed
@@ -720,7 +721,7 @@ def parse_pnml_into_lpn(filepath:str) -> LabelledPetriNet:
         else:
             silent = False
         # making a transition
-        tid = lid if lid != None else id 
+        tid = lid if lid != None and use_localnode_id else id 
         transition_ids[id] = tid 
         parsed = Transition( 
             transition.find("name").find("text").text,
@@ -744,7 +745,7 @@ def parse_pnml_into_lpn(filepath:str) -> LabelledPetriNet:
         src = node_ids[arc.attrib["source"]]
         tgt = node_ids[arc.attrib["target"]]
         # making an arc 
-        aid = lid if lid != None else id  # we aren't storing the actual id??
+        aid = lid if lid != None and use_localnode_id else id  # we aren't storing the actual id??
         src_node = nodes[src]
         tgt_node = nodes[tgt]
         arcs.add(Arc(

--- a/pmkoalas/models/petrinet.py
+++ b/pmkoalas/models/petrinet.py
@@ -465,7 +465,7 @@ class PetriNetDOTFormatter:
         fstr = 'n{} [shape="box",margin="0, 0.1",label="{} {}",style="filled"];\n'
         tl = tran.name if tran.name and tran.name != 'tau' else '&tau;'
         fstr = f'n{str(ti)} [shape="box",margin="0, 0.1",'
-        fstr += f'label="{tran.weight}", style="filled",'
+        # fstr += f'label="{tran.weight}", style="filled",'
         height = self._default_height
         fstr += f'height="{height}", width="{height}"'
         fstr += '];\n'
@@ -476,8 +476,8 @@ class PetriNetDOTFormatter:
         return fstr.format('n' + str(pi),place.name)
 
     def transform_arc(self,arc) -> str:
-        from_node = self._nodemap[arc.from_node]
-        to_node = self._nodemap[arc.to_node]
+        from_node = self._nodemap[arc.from_node.nodeId]
+        to_node = self._nodemap[arc.to_node.nodeId]
         return f'n{from_node}->n{to_node}\n'
 
     def transform_net(self) -> str:
@@ -491,11 +491,11 @@ class PetriNetDOTFormatter:
         ni = 1
         for pl in self._pn.places:
             ni += 1
-            self._nodemap[pl] = ni
+            self._nodemap[pl.nodeId] = ni
             dotstr += self.transform_place(pl,ni)
         for tr in self._pn.transitions:
             ni += 1
-            self._nodemap[tr] = ni
+            self._nodemap[tr.nodeId] = ni
             dotstr += self.transform_transition(tr,ni)
         for ar in self._pn.arcs:
             dotstr += self.transform_arc(ar)

--- a/pmkoalas/models/petrinet.py
+++ b/pmkoalas/models/petrinet.py
@@ -554,11 +554,11 @@ def convert_net_to_xml(net:LabelledPetriNet,
                         'localNodeID' : getUUID()
                     }
                 )
-        if net.initial_marking and net.initial_marking.contains(place):
+        if net.initial_marking is not None and net.initial_marking.contains(place):
             imarking = ET.SubElement(placeNode,'initialMarking')
             text_node = ET.SubElement(imarking,'text')
             text_node.text = str(net.initial_marking._mark[place])
-        if net.final_marking and net.final_marking.contains(place):
+        if net.final_marking is not None and net.final_marking.contains(place):
             fmarking = ET.SubElement(placeNode,'finalMarking')
             text_node = ET.SubElement(fmarking,'text')
             text_node.text = str(net.final_marking._mark[place])

--- a/pmkoalas/simple.py
+++ b/pmkoalas/simple.py
@@ -7,8 +7,9 @@ from __future__ import annotations # required for typing checks
 from typing import Iterable, List, Mapping, Set, Tuple
 from copy import deepcopy
 from time import time
+from logging import DEBUG
 
-from pmkoalas._logging import info, debug, enable_logging
+from pmkoalas._logging import info, debug, enable_logging, get_logger
 from pmkoalas.directly import DirectlyFollowPair,FollowLanguage
 from pmkoalas.directly import DIRECTLY_SOURCE,DIRECTLY_END
 from pmkoalas.directly import extract_df_pairs
@@ -153,12 +154,13 @@ class EventLog():
                     continue
                 compute_time = time()
                 # build initial flow
-                info(f"working on :: {trace=} @ {freq=}")
+                debug(f"working on :: {trace=} @ {freq=}")
                 relations = extract_df_pairs(list(trace), freq=freq)
-                info(f"starting pair :: {relations[0]}")
-                for pair in relations[1:-1]:
-                    info(f"pair :: {pair}")
-                info(f"ending with :: {relations[-1]}")
+                debug(f"starting pair :: {relations[0]}")
+                if get_logger().level == DEBUG:
+                    for pair in relations[1:-1]:
+                        debug(f"pair :: {pair}")
+                debug(f"ending with :: {relations[-1]}")
 
                 # update lang
                 self._relations  = self._relations + \

--- a/readme.md
+++ b/readme.md
@@ -54,3 +54,9 @@ in detail.
 It is better to delete code that is not used, than to keep it
 around. You have written it once, you will write it better the 
 next time. Don't be afraid to let it go.
+
+## Politely ask for more resources
+
+While many optimisations can be done when asking for more threads and 
+resources of the user's system, such optimisations should always be turned 
+off by default. 

--- a/tests/conformance/test_tokenplay.py
+++ b/tests/conformance/test_tokenplay.py
@@ -1,0 +1,51 @@
+import unittest
+
+from pmkoalas.models.pnfrag import parse_net_fragments
+from pmkoalas.simple import Trace
+from pmkoalas._logging import setLevel, info
+from logging import INFO,ERROR
+from pmkoalas.models.petrinet import Place
+from pmkoalas.conformance.tokenreplay import generate_traces_from_lpn
+
+test_lpn = parse_net_fragments(
+    "test_lpn_seq",
+    "I__1 -> [A] -> p1__2 -> [B] -> p2__3 -> [C] -> F__4"
+)
+test_lpn.set_initial_marking({Place("I", 1):1})
+test_lpn.set_final_marking({Place("F",4):1})
+test_lpn_par = parse_net_fragments(
+    "test_lpn_par",
+    "I__1 -> [A] -> p1__2 -> [B] -> p2__3 -> [C] -> F__4",
+    "I__1 -> [A] -> p5__5 -> [D] -> p6__6 -> [C] -> F__4"
+)
+test_lpn_par.set_initial_marking({Place("I", 1):1})
+test_lpn_par.set_final_marking({Place("F",4):1})
+
+class MatchingTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        # setLevel(INFO)
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        # setLevel(ERROR)
+
+    def test_generate_max_len(self):
+        log = generate_traces_from_lpn(test_lpn, 3)
+        self.assertEqual(1,len(log))
+        self.assertEqual(set([Trace(["A","B","C"])]), log.language())
+        log = generate_traces_from_lpn(test_lpn, 3, True)
+        self.assertEqual(set([Trace(["A","B","C"])]), log.language())
+        log = generate_traces_from_lpn(test_lpn, 2)
+        self.assertEqual(set([Trace(["A","B",])]), log.language())
+        log = generate_traces_from_lpn(test_lpn, 2, strict=True)
+        self.assertEqual(set(), log.language())
+
+    def test_parallel_gen(self):
+        log = generate_traces_from_lpn(test_lpn_par, 4)
+        self.assertEqual(2,len(log))
+        self.assertEqual(
+            set([Trace(['A','D','B','C']), Trace(['A','B','D','C'])]),
+            log.language()
+        )

--- a/tests/discovery/test_alpha.py
+++ b/tests/discovery/test_alpha.py
@@ -292,7 +292,6 @@ class OptimisedAlphaTest(SingleThreadAlphaTest):
     def setUp(self):
         from pmkoalas._logging import setLevel
         from logging import INFO
-        setLevel(INFO)
         self.miner = AlphaMinerInstance(optimised=True)
 
     def tearDown(self) -> None:

--- a/tests/discovery/test_alpha_plus.py
+++ b/tests/discovery/test_alpha_plus.py
@@ -464,7 +464,8 @@ alpha_plus_lpn_4 = LabelledPetriNet(
         ],
         name='Petri net'
 )
-alpha_plus_log_5 = EventLog(
+alpha_plus_log_5 = eval(
+"""EventLog(
 	[Trace(['a','b','f','i','d','h','j'])] * 1+
 	[Trace(['a','b','f','d','i','h','j'])] * 1+
 	[Trace(['a','b','f','d','h','i','j'])] * 1+
@@ -1220,7 +1221,8 @@ alpha_plus_log_5 = EventLog(
 	[Trace(['a','d','b','c','b','c','b','f','i','h','j'])] * 1+
 	[Trace(['a','d','b','c','b','c','b','f','h','i','j'])] * 1+
 	[Trace(['a','d','b','c','b','c','b','h','f','i','j'])] * 1
-) 
+)"""
+)
 alpha_plus_lpn_5 = LabelledPetriNet(
         places=[
                 Place("P_sink",pid="dbdd0237-8ad1-41e6-8304-b936ae99afd0"),

--- a/tests/discovery/test_alpha_plus.py
+++ b/tests/discovery/test_alpha_plus.py
@@ -1,0 +1,1422 @@
+import unittest
+from copy import deepcopy
+
+from pmkoalas.simple import Trace,EventLog
+from pmkoalas.discovery.alpha_miner import AlphaMinerPlusInstance
+from pmkoalas.discovery.alpha_miner import AlphaRelation,AlphaPair
+from pmkoalas.discovery.alpha_miner import AlphaPlace,AlphaFlowRelation
+from pmkoalas.discovery.alpha_miner import AlphaTransition
+from pmkoalas.discovery.alpha_miner import AlphaSinkPlace,AlphaStartPlace
+from pmkoalas.models.petrinet import Place,Transition,Arc,LabelledPetriNet
+from pmkoalas.dtlog import convert
+
+# simple log tests
+LOG = convert( 
+            "a b d",
+            "a c d",
+            "a b",
+            "a c",
+            "a b d e b d",
+            "a c d e c d"
+        )
+START_ACTS = set(["a"])
+END_ACTS = set(["d", "b", "c"])
+ACTS = set(["a", "b", "c", "d", "e"])
+MATRIX = { 
+    "a" : {
+        "a" : AlphaRelation("a","a",[]),
+        "b" : AlphaRelation("a","b",[("a","b")]),
+        "c" : AlphaRelation("a","c",[("a","c")]),
+        "d" : AlphaRelation("a","d",[]),
+        "e" : AlphaRelation("a","e",[])
+    },
+    "b" : {
+        "a" : AlphaRelation("b","a",[("a","b")]),
+        "b" : AlphaRelation("b","b",[]),
+        "c" : AlphaRelation("b","c",[]),
+        "d" : AlphaRelation("b","d",[("b","d")]),
+        "e" : AlphaRelation("b","e",[("e","b")])
+    },
+    "c" : {
+        "a" : AlphaRelation("c","a",[("a","c")]),
+        "b" : AlphaRelation("c","b",[]),
+        "c" : AlphaRelation("c","c",[]),
+        "d" : AlphaRelation("c","d",[("c","d")]),
+        "e" : AlphaRelation("c","e",[("e","c")])
+    },
+    "d" : {
+        "a" : AlphaRelation("d","a",[]),
+        "b" : AlphaRelation("d","b",[("b","d")]),
+        "c" : AlphaRelation("d","c",[("c","d")]),
+        "d" : AlphaRelation("d","d",[]),
+        "e" : AlphaRelation("d","e",[("d","e")])
+    },
+    "e" : {
+        "a" : AlphaRelation("e","a",[]),
+        "b" : AlphaRelation("e","b",[("e","b")]),
+        "c" : AlphaRelation("e","c",[("e","c")]),
+        "d" : AlphaRelation("e","d",[("d","e")]),
+        "e" : AlphaRelation("e","e",[])
+    }
+}
+
+# following p173 and L5 in Process Mining (2016;2ND ED)
+BOOK_LOG = convert( 
+    "a b e f",
+    "a b e f",
+    "a b e c d b f",
+    "a b e c d b f",
+    "a b e c d b f",
+    "a b c e d b f",
+    "a b c e d b f",
+    "a b c d e b f",
+    "a b c d e b f",
+    "a b c d e b f",
+    "a b c d e b f",
+    "a e b c d b f",
+    "a e b c d b f",
+    "a e b c d b f",
+)
+BOOK_TL = set(["a", "b", "c", "d", "e", "f"])
+BOOK_TL_OUT = set([ AlphaTransition(t) for t in BOOK_TL])
+BOOK_TI = set(["a"])
+BOOK_TO = set(["f"])
+BOOK_XL = set([ 
+    AlphaPair(set(["a"]),set(["b"])),
+    AlphaPair(set(["a"]), set(["e"])),
+    AlphaPair(set(["b"]), set(["c"])),
+    AlphaPair(set(["b"]), set(["f"])),
+    AlphaPair(set(["c"]), set(["d"])),
+    AlphaPair(set(["d"]), set(["b"])),
+    AlphaPair(set(["e"]), set(["f"])),
+    AlphaPair(set(["a","d"]), set(["b"])),
+    AlphaPair(set(["b"]), set(["c","f"])),
+])
+BOOK_YL = [
+    AlphaPair(set(["a"]), set(["e"])),
+    AlphaPair(set(["c"]), set(["d"])),
+    AlphaPair(set(["e"]), set(["f"])),
+    AlphaPair(set(["a","d"]), set(["b"])),
+    AlphaPair(set(["b"]), set(["c","f"])),
+]
+BOOK_PL = [ 
+    AlphaPlace(BOOK_YL[0].__str__(), BOOK_YL[0].left, BOOK_YL[0].right),
+    AlphaPlace(BOOK_YL[1].__str__(), BOOK_YL[1].left, BOOK_YL[1].right),
+    AlphaPlace(BOOK_YL[2].__str__(), BOOK_YL[2].left, BOOK_YL[2].right),
+    AlphaPlace(BOOK_YL[3].__str__(), BOOK_YL[3].left, BOOK_YL[3].right),
+    AlphaPlace(BOOK_YL[4].__str__(), BOOK_YL[4].left, BOOK_YL[4].right),
+    AlphaStartPlace(),
+    AlphaSinkPlace(),
+]
+BOOK_FL = set([ 
+    AlphaFlowRelation("1", AlphaTransition("a"), BOOK_PL[0]),
+    AlphaFlowRelation("2", BOOK_PL[0], AlphaTransition("e")),
+    AlphaFlowRelation("3", AlphaTransition("c"), BOOK_PL[1]),
+    AlphaFlowRelation("4", BOOK_PL[1], AlphaTransition("d")),
+    AlphaFlowRelation("5", AlphaTransition("e"), BOOK_PL[2]),
+    AlphaFlowRelation("6", BOOK_PL[2], AlphaTransition("f")),
+    AlphaFlowRelation("7", AlphaTransition("a"), BOOK_PL[3]),
+    AlphaFlowRelation("8", AlphaTransition("d"), BOOK_PL[3]),
+    AlphaFlowRelation("9", BOOK_PL[3], AlphaTransition("b")),
+    AlphaFlowRelation("10", AlphaTransition("b"), BOOK_PL[4]),
+    AlphaFlowRelation("11", BOOK_PL[4], AlphaTransition("c")),
+    AlphaFlowRelation("12", BOOK_PL[4], AlphaTransition("f")),
+    AlphaFlowRelation("13", BOOK_PL[5], AlphaTransition("a")),
+    AlphaFlowRelation("14", AlphaTransition("f"), BOOK_PL[6]),    
+])
+BOOK_YL = set(BOOK_YL)
+BOOK_PL = set(BOOK_PL)
+BOOK_LPN_PL = set([
+    Place(p.name) 
+    for p
+    in BOOK_PL
+])
+BOOK_LPN_TL = set([
+    Transition(t)
+    for t in BOOK_TL
+])
+place_nodes = dict( 
+    (p.name, p)
+    for p in BOOK_LPN_PL
+)
+transition_nodes = dict(
+    (t.name, t)
+    for t in BOOK_LPN_TL
+)
+BOOK_LPN_FL = set([
+    Arc(place_nodes[f.src.name], transition_nodes[f.tar.name])
+    if isinstance(f.src, AlphaPlace) else
+    Arc(transition_nodes[f.src.name], place_nodes[f.tar.name])
+    for f in BOOK_FL
+])
+
+alpha_plus_log_1 = log_a = convert(
+    "a b",
+    "a c f",
+    "a c d b",
+    "a c d c d b",
+    "a c d c d c f",
+    "e f",
+    "e d b",
+    "e d c d b",
+    "e d c f"
+)
+alpha_plus_lpn_1 = LabelledPetriNet(
+    places=[
+            Place("P_initial",pid="e24a7736-a912-4a3f-9eae-eee069655b56"),
+            Place("P_({'a', 'd'},{'b', 'c'})",pid="9b3d3f91-69f0-4706-b776-2ec017a0212a"),
+            Place("P_sink",pid="b70330d4-53ee-4db8-9c4d-16d045b7e77f"),
+            Place("P_({'c', 'e'},{'d', 'f'})",pid="36fdb6b7-2d5b-4802-ab11-aeeb95e3dad4"),
+    ],
+    transitions=[
+            Transition("f",tid="6bc0ba57-46c3-4cfd-8c65-9d17eb48a7cd",weight=1.0,silent=False),
+            Transition("b",tid="3ec3e270-35fb-4a9d-bb00-9a523498c23e",weight=1.0,silent=False),
+            Transition("c",tid="84598e1b-ba53-4ee4-8400-22abb2fc333f",weight=1.0,silent=False),
+            Transition("d",tid="ea1b3360-4045-4a59-b147-804d747416e3",weight=1.0,silent=False),
+            Transition("a",tid="3bab0469-ef26-4adc-a6f4-f9cd4dd69a29",weight=1.0,silent=False),
+            Transition("e",tid="6af4d9fe-deda-4020-ad5e-bfb88ce23d3b",weight=1.0,silent=False),
+    ],
+    arcs=[
+            Arc(from_node=Place("P_({'c', 'e'},{'d', 'f'})",pid="36fdb6b7-2d5b-4802-ab11-aeeb95e3dad4"),to_node=Transition("d",tid="ea1b3360-4045-4a59-b147-804d747416e3",weight=1.0,silent=False)),
+            Arc(from_node=Transition("e",tid="6af4d9fe-deda-4020-ad5e-bfb88ce23d3b",weight=1.0,silent=False),to_node=Place("P_({'c', 'e'},{'d', 'f'})",pid="36fdb6b7-2d5b-4802-ab11-aeeb95e3dad4")),
+            Arc(from_node=Transition("b",tid="3ec3e270-35fb-4a9d-bb00-9a523498c23e",weight=1.0,silent=False),to_node=Place("P_sink",pid="b70330d4-53ee-4db8-9c4d-16d045b7e77f")),
+            Arc(from_node=Transition("c",tid="84598e1b-ba53-4ee4-8400-22abb2fc333f",weight=1.0,silent=False),to_node=Place("P_({'c', 'e'},{'d', 'f'})",pid="36fdb6b7-2d5b-4802-ab11-aeeb95e3dad4")),
+            Arc(from_node=Place("P_({'a', 'd'},{'b', 'c'})",pid="9b3d3f91-69f0-4706-b776-2ec017a0212a"),to_node=Transition("c",tid="84598e1b-ba53-4ee4-8400-22abb2fc333f",weight=1.0,silent=False)),
+            Arc(from_node=Place("P_initial",pid="e24a7736-a912-4a3f-9eae-eee069655b56"),to_node=Transition("e",tid="6af4d9fe-deda-4020-ad5e-bfb88ce23d3b",weight=1.0,silent=False)),
+            Arc(from_node=Transition("f",tid="6bc0ba57-46c3-4cfd-8c65-9d17eb48a7cd",weight=1.0,silent=False),to_node=Place("P_sink",pid="b70330d4-53ee-4db8-9c4d-16d045b7e77f")),
+            Arc(from_node=Transition("a",tid="3bab0469-ef26-4adc-a6f4-f9cd4dd69a29",weight=1.0,silent=False),to_node=Place("P_({'a', 'd'},{'b', 'c'})",pid="9b3d3f91-69f0-4706-b776-2ec017a0212a")),
+            Arc(from_node=Transition("d",tid="ea1b3360-4045-4a59-b147-804d747416e3",weight=1.0,silent=False),to_node=Place("P_({'a', 'd'},{'b', 'c'})",pid="9b3d3f91-69f0-4706-b776-2ec017a0212a")),
+            Arc(from_node=Place("P_({'c', 'e'},{'d', 'f'})",pid="36fdb6b7-2d5b-4802-ab11-aeeb95e3dad4"),to_node=Transition("f",tid="6bc0ba57-46c3-4cfd-8c65-9d17eb48a7cd",weight=1.0,silent=False)),
+            Arc(from_node=Place("P_initial",pid="e24a7736-a912-4a3f-9eae-eee069655b56"),to_node=Transition("a",tid="3bab0469-ef26-4adc-a6f4-f9cd4dd69a29",weight=1.0,silent=False)),
+            Arc(from_node=Place("P_({'a', 'd'},{'b', 'c'})",pid="9b3d3f91-69f0-4706-b776-2ec017a0212a"),to_node=Transition("b",tid="3ec3e270-35fb-4a9d-bb00-9a523498c23e",weight=1.0,silent=False)),
+    ],
+    name='Petri net'
+)
+alpha_plus_log_2 = convert(
+    "a b d",
+    "a b c b d",
+    "a b c b c b d",
+)
+alpha_plus_lpn_2 = LabelledPetriNet(
+        places=[
+                Place("P_({'a', 'c'},{'b'})",pid="efe9d0f8-757a-4483-985b-0df527d0404e"),
+                Place("P_({'b'},{'c', 'd'})",pid="fb89b421-d116-4a15-9c40-70f0d83b4153"),
+                Place("P_initial",pid="b2c6b279-18c8-4cf8-8ac6-9e06c2bb0fd8"),
+                Place("P_sink",pid="c6afa143-dad7-40ce-a15e-5cf7dba08529"),
+        ],
+        transitions=[
+                Transition("d",tid="c4d8d2e3-942b-4472-b5a1-06e900b1dd41",weight=1.0,silent=False),
+                Transition("a",tid="12a0a456-9aa8-48cd-a609-5cf5442d3a1f",weight=1.0,silent=False),
+                Transition("c",tid="38eaecb9-2e9f-4c44-915c-59fe6288509f",weight=1.0,silent=False),
+                Transition("b",tid="e68c86b5-49e3-4bde-85e3-59c18e1dc314",weight=1.0,silent=False),
+        ],
+        arcs=[
+                Arc(from_node=Place("P_({'b'},{'c', 'd'})",pid="fb89b421-d116-4a15-9c40-70f0d83b4153"),to_node=Transition("d",tid="c4d8d2e3-942b-4472-b5a1-06e900b1dd41",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'a', 'c'},{'b'})",pid="efe9d0f8-757a-4483-985b-0df527d0404e"),to_node=Transition("b",tid="e68c86b5-49e3-4bde-85e3-59c18e1dc314",weight=1.0,silent=False)),
+                Arc(from_node=Transition("d",tid="c4d8d2e3-942b-4472-b5a1-06e900b1dd41",weight=1.0,silent=False),to_node=Place("P_sink",pid="c6afa143-dad7-40ce-a15e-5cf7dba08529")),
+                Arc(from_node=Transition("b",tid="e68c86b5-49e3-4bde-85e3-59c18e1dc314",weight=1.0,silent=False),to_node=Place("P_({'b'},{'c', 'd'})",pid="fb89b421-d116-4a15-9c40-70f0d83b4153")),
+                Arc(from_node=Transition("a",tid="12a0a456-9aa8-48cd-a609-5cf5442d3a1f",weight=1.0,silent=False),to_node=Place("P_({'a', 'c'},{'b'})",pid="efe9d0f8-757a-4483-985b-0df527d0404e")),
+                Arc(from_node=Transition("c",tid="38eaecb9-2e9f-4c44-915c-59fe6288509f",weight=1.0,silent=False),to_node=Place("P_({'a', 'c'},{'b'})",pid="efe9d0f8-757a-4483-985b-0df527d0404e")),
+                Arc(from_node=Place("P_initial",pid="b2c6b279-18c8-4cf8-8ac6-9e06c2bb0fd8"),to_node=Transition("a",tid="12a0a456-9aa8-48cd-a609-5cf5442d3a1f",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'b'},{'c', 'd'})",pid="fb89b421-d116-4a15-9c40-70f0d83b4153"),to_node=Transition("c",tid="38eaecb9-2e9f-4c44-915c-59fe6288509f",weight=1.0,silent=False)),
+        ],
+        name='Petri net'
+)
+alpha_plus_log_3 = convert(
+    "a b d",
+    "a b c b d",
+    "a b c b c b d",
+    "a b b d",
+    "a b b b d",
+    "a b b c d",
+    "a b b c c d",
+    "a c c b b d",
+    "a c b c b d"
+)
+alpha_plus_lpn_3 = LabelledPetriNet(
+        places=[
+                Place("P_initial",pid="58be6669-72ef-4a49-90ed-c006d6afa600"),
+                Place("P_sink",pid="b62de061-6bf9-4cd3-8929-77821e042ea4"),
+                Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1"),
+        ],
+        transitions=[
+                Transition("a",tid="6b056e17-ea79-462d-ba02-f7698766588c",weight=1.0,silent=False),
+                Transition("b",tid="5552c955-359e-47b0-8fac-78a91e279e64",weight=1.0,silent=False),
+                Transition("c",tid="ad86bd4d-cc2e-47a0-95b1-d866d54dd6df",weight=1.0,silent=False),
+                Transition("d",tid="8241ba0f-cd6c-4f9d-a9f9-318b761b1b3a",weight=1.0,silent=False),
+        ],
+        arcs=[
+                Arc(from_node=Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1"),to_node=Transition("c",tid="ad86bd4d-cc2e-47a0-95b1-d866d54dd6df",weight=1.0,silent=False)),
+                Arc(from_node=Transition("a",tid="6b056e17-ea79-462d-ba02-f7698766588c",weight=1.0,silent=False),to_node=Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1")),
+                Arc(from_node=Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1"),to_node=Transition("d",tid="8241ba0f-cd6c-4f9d-a9f9-318b761b1b3a",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1"),to_node=Transition("b",tid="5552c955-359e-47b0-8fac-78a91e279e64",weight=1.0,silent=False)),
+                Arc(from_node=Transition("b",tid="5552c955-359e-47b0-8fac-78a91e279e64",weight=1.0,silent=False),to_node=Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1")),
+                Arc(from_node=Place("P_initial",pid="58be6669-72ef-4a49-90ed-c006d6afa600"),to_node=Transition("a",tid="6b056e17-ea79-462d-ba02-f7698766588c",weight=1.0,silent=False)),
+                Arc(from_node=Transition("d",tid="8241ba0f-cd6c-4f9d-a9f9-318b761b1b3a",weight=1.0,silent=False),to_node=Place("P_sink",pid="b62de061-6bf9-4cd3-8929-77821e042ea4")),
+                Arc(from_node=Transition("c",tid="ad86bd4d-cc2e-47a0-95b1-d866d54dd6df",weight=1.0,silent=False),to_node=Place("P_({'a'},{'d'})",pid="53579d87-9431-4031-833b-a307a59da0a1")),
+        ],
+        name='Petri net'
+)
+alpha_plus_log_4 = EventLog(
+        [Trace(['a','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','h'])] * 1+
+        [Trace(['a','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','f','h'])] * 1+
+        [Trace(['a','b','c','e','f','h'])] * 1+
+        [Trace(['a','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','f','h'])] * 1+
+        [Trace(['a','b','c','f','g','f','h'])] * 1+
+        [Trace(['a','b','c','d','c','f','h'])] * 1+
+        [Trace(['a','b','c','e','e','f','h'])] * 1+
+        [Trace(['a','b','b','c','e','f','h'])] * 1+
+        [Trace(['a','b','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','f','g','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','e','f','h'])] * 1+
+        [Trace(['a','b','c','f','g','e','f','h'])] * 1+
+        [Trace(['a','b','c','d','c','e','f','h'])] * 1+
+        [Trace(['a','b','c','d','b','c','f','h'])] * 1+
+        [Trace(['a','b','c','e','f','g','f','h'])] * 1+
+        [Trace(['a','b','c','e','d','c','f','h'])] * 1+
+        [Trace(['a','b','c','e','e','e','f','h'])] * 1+
+        [Trace(['a','b','b','c','f','g','f','h'])] * 1+
+        [Trace(['a','b','b','c','d','c','f','h'])] * 1+
+        [Trace(['a','b','b','c','e','e','f','h'])] * 1+
+        [Trace(['a','b','b','b','c','e','f','h'])] * 1+
+        [Trace(['a','b','b','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','e','e','f','h'])] * 1+
+        [Trace(['a','b','c','f','g','f','g','f','h'])] * 1+
+        [Trace(['a','b','c','f','g','d','c','f','h'])] * 1+
+        [Trace(['a','b','c','f','g','e','e','f','h'])] * 1+
+        [Trace(['a','b','c','d','c','f','g','f','h'])] * 1+
+        [Trace(['a','b','c','d','c','d','c','f','h'])] * 1+
+        [Trace(['a','b','c','d','c','e','e','f','h'])] * 1+
+        [Trace(['a','b','c','d','b','c','e','f','h'])] * 1+
+        [Trace(['a','b','c','d','b','b','c','f','h'])] * 1+
+        [Trace(['a','b','c','e','f','g','e','f','h'])] * 1+
+        [Trace(['a','b','c','e','d','c','e','f','h'])] * 1+
+        [Trace(['a','b','c','e','d','b','c','f','h'])] * 1+
+        [Trace(['a','b','c','e','e','f','g','f','h'])] * 1+
+        [Trace(['a','b','c','e','e','d','c','f','h'])] * 1+
+        [Trace(['a','b','c','e','e','e','e','f','h'])] * 1+
+        [Trace(['a','b','b','c','f','g','e','f','h'])] * 1+
+        [Trace(['a','b','b','c','d','c','e','f','h'])] * 1+
+        [Trace(['a','b','b','c','d','b','c','f','h'])] * 1+
+        [Trace(['a','b','b','c','e','f','g','f','h'])] * 1+
+        [Trace(['a','b','b','c','e','d','c','f','h'])] * 1+
+        [Trace(['a','b','b','c','e','e','e','f','h'])] * 1+
+        [Trace(['a','b','b','b','c','f','g','f','h'])] * 1+
+        [Trace(['a','b','b','b','c','d','c','f','h'])] * 1+
+        [Trace(['a','b','b','b','c','e','e','f','h'])] * 1+
+        [Trace(['a','b','b','b','b','c','e','f','h'])] * 1+
+        [Trace(['a','b','b','b','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','f','g','f','g','f','h'])] * 1+
+        [Trace(['a','c','f','g','f','g','d','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','f','g','e','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','d','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','f','g','e','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','f','g','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','c','f','g','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','f','g','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','d','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','c','e','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','b','c','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','d','b','b','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','f','g','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','d','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','e','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','e','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','d','c','e','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','d','b','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','f','g','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','e','f','g','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','f','g','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','c','f','g','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','c','d','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','c','e','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','b','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','d','b','b','c','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','f','g','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','d','c','e','f','h'])] * 1+
+        [Trace(['a','c','e','e','e','d','b','c','f','h'])] * 1
+)
+alpha_plus_lpn_4 = LabelledPetriNet(
+        places=[
+                Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0"),      
+                Place("P_({'a', 'd'},{'c'})",pid="2782e2ef-3947-4b94-b61f-af462dfe4c6a"),
+                Place("P_({'f'},{'g', 'h'})",pid="3ce5ed1e-c6cb-4c63-aa0c-a16b1f467f76"),
+                Place("P_sink",pid="958f7ae7-6525-4c5d-87dd-5cb991e2fc8d"),
+                Place("P_initial",pid="45452dc7-3d9d-4cca-a585-cf26ddd02526"),
+        ],
+        transitions=[
+                Transition("e",tid="ffe1fce2-e81a-4f6c-b4b9-817b9fe558fe",weight=1.0,silent=False), 
+                Transition("d",tid="233e8e3f-af75-44ca-8a91-c0457840ea72",weight=1.0,silent=False), 
+                Transition("a",tid="67f34c5e-1cba-475f-8c0a-d2429d5ecb4f",weight=1.0,silent=False), 
+                Transition("b",tid="2020a137-1dae-4534-b4aa-38a48c5ae238",weight=1.0,silent=False), 
+                Transition("c",tid="9cc9da20-78ce-4a7f-b9d7-35ce7c7fcc41",weight=1.0,silent=False), 
+                Transition("g",tid="d4d2b513-90bb-4651-9607-37beb3a73af9",weight=1.0,silent=False), 
+                Transition("h",tid="6832baf4-c712-416c-9327-f19c8f736419",weight=1.0,silent=False), 
+                Transition("f",tid="ffbfd3e5-a05e-4b90-82ea-f938f47ba85c",weight=1.0,silent=False), 
+        ],
+        arcs=[
+                Arc(from_node=Transition("f",tid="ffbfd3e5-a05e-4b90-82ea-f938f47ba85c",weight=1.0,silent=False),to_node=Place("P_({'f'},{'g', 'h'})",pid="3ce5ed1e-c6cb-4c63-aa0c-a16b1f467f76")),     
+                Arc(from_node=Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0"),to_node=Transition("d",tid="233e8e3f-af75-44ca-8a91-c0457840ea72",weight=1.0,silent=False)),
+                Arc(from_node=Transition("h",tid="6832baf4-c712-416c-9327-f19c8f736419",weight=1.0,silent=False),to_node=Place("P_sink",pid="958f7ae7-6525-4c5d-87dd-5cb991e2fc8d")),
+                Arc(from_node=Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0"),to_node=Transition("e",tid="ffe1fce2-e81a-4f6c-b4b9-817b9fe558fe",weight=1.0,silent=False)),
+                Arc(from_node=Transition("e",tid="ffe1fce2-e81a-4f6c-b4b9-817b9fe558fe",weight=1.0,silent=False),to_node=Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0")),
+                Arc(from_node=Place("P_({'a', 'd'},{'c'})",pid="2782e2ef-3947-4b94-b61f-af462dfe4c6a"),to_node=Transition("b",tid="2020a137-1dae-4534-b4aa-38a48c5ae238",weight=1.0,silent=False)),     
+                Arc(from_node=Transition("b",tid="2020a137-1dae-4534-b4aa-38a48c5ae238",weight=1.0,silent=False),to_node=Place("P_({'a', 'd'},{'c'})",pid="2782e2ef-3947-4b94-b61f-af462dfe4c6a")),     
+                Arc(from_node=Place("P_({'a', 'd'},{'c'})",pid="2782e2ef-3947-4b94-b61f-af462dfe4c6a"),to_node=Transition("c",tid="9cc9da20-78ce-4a7f-b9d7-35ce7c7fcc41",weight=1.0,silent=False)),     
+                Arc(from_node=Transition("g",tid="d4d2b513-90bb-4651-9607-37beb3a73af9",weight=1.0,silent=False),to_node=Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0")),
+                Arc(from_node=Place("P_initial",pid="45452dc7-3d9d-4cca-a585-cf26ddd02526"),to_node=Transition("a",tid="67f34c5e-1cba-475f-8c0a-d2429d5ecb4f",weight=1.0,silent=False)),
+                Arc(from_node=Transition("a",tid="67f34c5e-1cba-475f-8c0a-d2429d5ecb4f",weight=1.0,silent=False),to_node=Place("P_({'a', 'd'},{'c'})",pid="2782e2ef-3947-4b94-b61f-af462dfe4c6a")),     
+                Arc(from_node=Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0"),to_node=Transition("f",tid="ffbfd3e5-a05e-4b90-82ea-f938f47ba85c",weight=1.0,silent=False)),
+                Arc(from_node=Transition("c",tid="9cc9da20-78ce-4a7f-b9d7-35ce7c7fcc41",weight=1.0,silent=False),to_node=Place("P_({'c', 'g'},{'d', 'f'})",pid="00bc70ae-8007-46c7-9442-f05f23d114d0")),
+                Arc(from_node=Place("P_({'f'},{'g', 'h'})",pid="3ce5ed1e-c6cb-4c63-aa0c-a16b1f467f76"),to_node=Transition("g",tid="d4d2b513-90bb-4651-9607-37beb3a73af9",weight=1.0,silent=False)),     
+                Arc(from_node=Transition("d",tid="233e8e3f-af75-44ca-8a91-c0457840ea72",weight=1.0,silent=False),to_node=Place("P_({'a', 'd'},{'c'})",pid="2782e2ef-3947-4b94-b61f-af462dfe4c6a")),     
+                Arc(from_node=Place("P_({'f'},{'g', 'h'})",pid="3ce5ed1e-c6cb-4c63-aa0c-a16b1f467f76"),to_node=Transition("h",tid="6832baf4-c712-416c-9327-f19c8f736419",weight=1.0,silent=False)),     
+        ],
+        name='Petri net'
+)
+alpha_plus_log_5 = EventLog(
+	[Trace(['a','b','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','h','f','i','j'])] * 1+
+	[Trace(['a','d','h','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','i','d','z','h','j'])] * 2+
+	[Trace(['a','b','f','d','i','z','h','j'])] * 2+
+	[Trace(['a','b','f','d','z','i','h','j'])] * 2+
+	[Trace(['a','b','f','d','z','h','i','j'])] * 2+
+	[Trace(['a','b','d','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','d','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','d','f','z','h','i','j'])] * 2+
+	[Trace(['a','d','z','h','b','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','f','i','h','j'])] * 2+
+	[Trace(['a','d','z','b','f','h','i','j'])] * 2+
+	[Trace(['a','d','z','b','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','z','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','z','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','f','i','z','h','j'])] * 2+
+	[Trace(['a','d','b','f','z','i','h','j'])] * 2+
+	[Trace(['a','d','b','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','f','i','d','z','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','d','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','f','e','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','c','b','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','d','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','d','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','d','z','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','z','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','h','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','h','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','i','d','z','z','z','h','j'])] * 8+
+	[Trace(['a','b','f','d','i','z','z','z','h','j'])] * 8+
+	[Trace(['a','b','f','d','e','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','f','d','e','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','f','d','e','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','f','d','e','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','f','d','e','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','f','d','e','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','f','d','z','i','z','z','h','j'])] * 8+
+	[Trace(['a','b','f','d','z','e','f','i','h','j'])] * 2+
+	[Trace(['a','b','f','d','z','e','f','h','i','j'])] * 2+
+	[Trace(['a','b','f','d','z','e','h','f','i','j'])] * 2+
+	[Trace(['a','b','f','d','z','z','i','z','h','j'])] * 8+
+	[Trace(['a','b','f','d','z','z','z','i','h','j'])] * 8+
+	[Trace(['a','b','f','d','z','z','z','h','i','j'])] * 8+
+	[Trace(['a','b','f','d','z','h','e','f','i','j'])] * 2+
+	[Trace(['a','b','f','e','f','i','d','z','h','j'])] * 2+
+	[Trace(['a','b','f','e','f','d','i','z','h','j'])] * 2+
+	[Trace(['a','b','f','e','f','d','z','i','h','j'])] * 2+
+	[Trace(['a','b','f','e','f','d','z','h','i','j'])] * 2+
+	[Trace(['a','b','f','e','d','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','f','e','d','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','f','e','d','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','f','e','d','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','f','e','d','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','f','e','d','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','c','b','f','i','d','z','h','j'])] * 2+
+	[Trace(['a','b','c','b','f','d','i','z','h','j'])] * 2+
+	[Trace(['a','b','c','b','f','d','z','i','h','j'])] * 2+
+	[Trace(['a','b','c','b','f','d','z','h','i','j'])] * 2+
+	[Trace(['a','b','c','b','d','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','c','b','d','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','c','b','d','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','c','b','d','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','c','b','d','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','c','b','d','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','c','d','z','h','b','f','i','j'])] * 2+
+	[Trace(['a','b','c','d','z','b','f','i','h','j'])] * 2+
+	[Trace(['a','b','c','d','z','b','f','h','i','j'])] * 2+
+	[Trace(['a','b','c','d','z','b','h','f','i','j'])] * 2+
+	[Trace(['a','b','c','d','b','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','c','d','b','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','c','d','b','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','c','d','b','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','c','d','b','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','c','d','b','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','d','z','z','z','f','i','h','j'])] * 8+
+	[Trace(['a','b','d','z','z','z','f','h','i','j'])] * 8+
+	[Trace(['a','b','d','z','z','z','h','f','i','j'])] * 8+
+	[Trace(['a','b','d','z','z','f','i','z','h','j'])] * 8+
+	[Trace(['a','b','d','z','z','f','z','i','h','j'])] * 8+
+	[Trace(['a','b','d','z','z','f','z','h','i','j'])] * 8+
+	[Trace(['a','b','d','z','f','i','z','z','h','j'])] * 8+
+	[Trace(['a','b','d','z','f','e','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','z','f','e','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','z','f','e','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','z','f','z','i','z','h','j'])] * 8+
+	[Trace(['a','b','d','z','f','z','z','i','h','j'])] * 8+
+	[Trace(['a','b','d','z','f','z','z','h','i','j'])] * 8+
+	[Trace(['a','b','d','z','f','h','e','f','i','j'])] * 2+
+	[Trace(['a','b','d','z','h','f','e','f','i','j'])] * 2+
+	[Trace(['a','b','d','z','h','c','b','f','i','j'])] * 2+
+	[Trace(['a','b','d','z','c','h','b','f','i','j'])] * 2+
+	[Trace(['a','b','d','z','c','b','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','z','c','b','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','z','c','b','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','f','i','z','z','z','h','j'])] * 8+
+	[Trace(['a','b','d','f','e','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','f','e','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','f','e','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','f','e','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','d','f','e','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','d','f','e','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','d','f','z','i','z','z','h','j'])] * 8+
+	[Trace(['a','b','d','f','z','e','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','f','z','e','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','f','z','e','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','f','z','z','i','z','h','j'])] * 8+
+	[Trace(['a','b','d','f','z','z','z','i','h','j'])] * 8+
+	[Trace(['a','b','d','f','z','z','z','h','i','j'])] * 8+
+	[Trace(['a','b','d','f','z','h','e','f','i','j'])] * 2+
+	[Trace(['a','b','d','c','z','h','b','f','i','j'])] * 2+
+	[Trace(['a','b','d','c','z','b','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','c','z','b','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','c','z','b','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','c','b','z','f','i','h','j'])] * 2+
+	[Trace(['a','b','d','c','b','z','f','h','i','j'])] * 2+
+	[Trace(['a','b','d','c','b','z','h','f','i','j'])] * 2+
+	[Trace(['a','b','d','c','b','f','i','z','h','j'])] * 2+
+	[Trace(['a','b','d','c','b','f','z','i','h','j'])] * 2+
+	[Trace(['a','b','d','c','b','f','z','h','i','j'])] * 2+
+	[Trace(['a','d','z','z','z','h','b','f','i','j'])] * 8+
+	[Trace(['a','d','z','z','z','b','f','i','h','j'])] * 8+
+	[Trace(['a','d','z','z','z','b','f','h','i','j'])] * 8+
+	[Trace(['a','d','z','z','z','b','h','f','i','j'])] * 8+
+	[Trace(['a','d','z','z','b','z','f','i','h','j'])] * 8+
+	[Trace(['a','d','z','z','b','z','f','h','i','j'])] * 8+
+	[Trace(['a','d','z','z','b','z','h','f','i','j'])] * 8+
+	[Trace(['a','d','z','z','b','f','i','z','h','j'])] * 8+
+	[Trace(['a','d','z','z','b','f','z','i','h','j'])] * 8+
+	[Trace(['a','d','z','z','b','f','z','h','i','j'])] * 8+
+	[Trace(['a','d','z','h','b','f','e','f','i','j'])] * 2+
+	[Trace(['a','d','z','h','b','c','b','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','z','z','f','i','h','j'])] * 8+
+	[Trace(['a','d','z','b','z','z','f','h','i','j'])] * 8+
+	[Trace(['a','d','z','b','z','z','h','f','i','j'])] * 8+
+	[Trace(['a','d','z','b','z','f','i','z','h','j'])] * 8+
+	[Trace(['a','d','z','b','z','f','z','i','h','j'])] * 8+
+	[Trace(['a','d','z','b','z','f','z','h','i','j'])] * 8+
+	[Trace(['a','d','z','b','f','i','z','z','h','j'])] * 8+
+	[Trace(['a','d','z','b','f','e','f','i','h','j'])] * 2+
+	[Trace(['a','d','z','b','f','e','f','h','i','j'])] * 2+
+	[Trace(['a','d','z','b','f','e','h','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','f','z','i','z','h','j'])] * 8+
+	[Trace(['a','d','z','b','f','z','z','i','h','j'])] * 8+
+	[Trace(['a','d','z','b','f','z','z','h','i','j'])] * 8+
+	[Trace(['a','d','z','b','f','h','e','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','h','f','e','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','h','c','b','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','c','h','b','f','i','j'])] * 2+
+	[Trace(['a','d','z','b','c','b','f','i','h','j'])] * 2+
+	[Trace(['a','d','z','b','c','b','f','h','i','j'])] * 2+
+	[Trace(['a','d','z','b','c','b','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','z','z','f','i','h','j'])] * 8+
+	[Trace(['a','d','b','z','z','z','f','h','i','j'])] * 8+
+	[Trace(['a','d','b','z','z','z','h','f','i','j'])] * 8+
+	[Trace(['a','d','b','z','z','f','i','z','h','j'])] * 8+
+	[Trace(['a','d','b','z','z','f','z','i','h','j'])] * 8+
+	[Trace(['a','d','b','z','z','f','z','h','i','j'])] * 8+
+	[Trace(['a','d','b','z','f','i','z','z','h','j'])] * 8+
+	[Trace(['a','d','b','z','f','e','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','z','f','e','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','z','f','e','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','f','z','i','z','h','j'])] * 8+
+	[Trace(['a','d','b','z','f','z','z','i','h','j'])] * 8+
+	[Trace(['a','d','b','z','f','z','z','h','i','j'])] * 8+
+	[Trace(['a','d','b','z','f','h','e','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','h','f','e','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','h','c','b','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','c','h','b','f','i','j'])] * 2+
+	[Trace(['a','d','b','z','c','b','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','z','c','b','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','z','c','b','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','f','i','z','z','z','h','j'])] * 8+
+	[Trace(['a','d','b','f','e','z','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','f','e','z','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','f','e','z','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','f','e','f','i','z','h','j'])] * 2+
+	[Trace(['a','d','b','f','e','f','z','i','h','j'])] * 2+
+	[Trace(['a','d','b','f','e','f','z','h','i','j'])] * 2+
+	[Trace(['a','d','b','f','z','i','z','z','h','j'])] * 8+
+	[Trace(['a','d','b','f','z','e','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','f','z','e','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','f','z','e','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','f','z','z','i','z','h','j'])] * 8+
+	[Trace(['a','d','b','f','z','z','z','i','h','j'])] * 8+
+	[Trace(['a','d','b','f','z','z','z','h','i','j'])] * 8+
+	[Trace(['a','d','b','f','z','h','e','f','i','j'])] * 2+
+	[Trace(['a','d','b','c','z','h','b','f','i','j'])] * 2+
+	[Trace(['a','d','b','c','z','b','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','c','z','b','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','c','z','b','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','c','b','z','f','i','h','j'])] * 2+
+	[Trace(['a','d','b','c','b','z','f','h','i','j'])] * 2+
+	[Trace(['a','d','b','c','b','z','h','f','i','j'])] * 2+
+	[Trace(['a','d','b','c','b','f','i','z','h','j'])] * 2+
+	[Trace(['a','d','b','c','b','f','z','i','h','j'])] * 2+
+	[Trace(['a','d','b','c','b','f','z','h','i','j'])] * 2+
+	[Trace(['a','b','f','i','d','z','z','z','z','h','j'])] * 16+
+	[Trace(['a','b','f','d','i','z','z','z','z','h','j'])] * 16+
+	[Trace(['a','b','f','d','e','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','e','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','f','d','e','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','e','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','d','e','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','e','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','e','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','d','e','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','d','e','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','z','i','z','z','z','h','j'])] * 16+
+	[Trace(['a','b','f','d','z','e','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','z','e','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','z','e','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','f','d','z','e','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','d','z','e','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','z','e','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','z','z','i','z','z','h','j'])] * 16+
+	[Trace(['a','b','f','d','z','z','e','f','i','h','j'])] * 4+
+	[Trace(['a','b','f','d','z','z','e','f','h','i','j'])] * 4+
+	[Trace(['a','b','f','d','z','z','e','h','f','i','j'])] * 4+
+	[Trace(['a','b','f','d','z','z','z','i','z','h','j'])] * 16+
+	[Trace(['a','b','f','d','z','z','z','z','i','h','j'])] * 16+
+	[Trace(['a','b','f','d','z','z','z','z','h','i','j'])] * 16+
+	[Trace(['a','b','f','d','z','z','h','e','f','i','j'])] * 4+
+	[Trace(['a','b','f','d','h','e','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','d','h','e','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','i','d','z','z','h','j'])] * 4+
+	[Trace(['a','b','f','e','f','d','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','f','e','f','d','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','f','d','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','d','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','d','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','e','f','d','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','e','f','d','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','e','f','d','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','e','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','f','e','f','e','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','f','e','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','e','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','f','e','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','f','e','d','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','c','b','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','f','e','c','b','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','c','b','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','c','b','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','c','b','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','c','b','d','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','c','d','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','c','d','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','c','d','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','c','d','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','f','e','d','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','f','e','d','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','f','e','d','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','e','d','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','e','d','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','e','d','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','f','e','d','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','d','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','f','e','d','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','f','e','d','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','f','e','d','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','f','e','d','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','f','e','d','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','i','d','z','z','h','j'])] * 4+
+	[Trace(['a','b','c','b','f','d','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','c','b','f','d','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','f','d','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','d','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','d','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','c','b','f','d','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','c','b','f','d','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','c','b','f','d','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','e','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','c','b','f','e','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','f','e','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','e','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','f','e','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','f','e','d','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','c','b','f','i','d','h','j'])] * 1+
+	[Trace(['a','b','c','b','c','b','f','d','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','c','b','f','d','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','c','b','d','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','c','b','d','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','c','b','d','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','c','d','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','c','d','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','c','d','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','c','d','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','c','b','d','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','c','b','d','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','c','b','d','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','c','b','d','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','c','b','d','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','c','b','d','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','c','b','d','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','d','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','c','b','d','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','c','b','d','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','c','b','d','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','b','d','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','b','d','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','z','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','b','c','d','z','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','b','c','d','z','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','b','c','d','z','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','b','c','d','z','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','c','d','z','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','c','d','z','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','c','d','z','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','c','d','z','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','c','d','z','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','c','d','h','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','h','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','c','d','b','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','c','d','b','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','c','d','b','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','c','d','b','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','c','d','b','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','c','d','b','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','c','d','b','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','d','b','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','c','d','b','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','c','d','b','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','c','d','b','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','c','d','b','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','c','d','b','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','d','z','z','z','z','f','i','h','j'])] * 16+
+	[Trace(['a','b','d','z','z','z','z','f','h','i','j'])] * 16+
+	[Trace(['a','b','d','z','z','z','z','h','f','i','j'])] * 16+
+	[Trace(['a','b','d','z','z','z','f','i','z','h','j'])] * 16+
+	[Trace(['a','b','d','z','z','z','f','z','i','h','j'])] * 16+
+	[Trace(['a','b','d','z','z','z','f','z','h','i','j'])] * 16+
+	[Trace(['a','b','d','z','z','f','i','z','z','h','j'])] * 16+
+	[Trace(['a','b','d','z','z','f','e','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','z','f','e','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','f','e','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','f','z','i','z','h','j'])] * 16+
+	[Trace(['a','b','d','z','z','f','z','z','i','h','j'])] * 16+
+	[Trace(['a','b','d','z','z','f','z','z','h','i','j'])] * 16+
+	[Trace(['a','b','d','z','z','f','h','e','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','h','f','e','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','h','c','b','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','c','h','b','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','c','b','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','z','c','b','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','z','c','b','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','i','z','z','z','h','j'])] * 16+
+	[Trace(['a','b','d','z','f','e','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','f','e','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','e','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','e','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','z','f','e','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','f','e','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','z','i','z','z','h','j'])] * 16+
+	[Trace(['a','b','d','z','f','z','e','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','f','z','e','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','z','e','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','f','z','z','i','z','h','j'])] * 16+
+	[Trace(['a','b','d','z','f','z','z','z','i','h','j'])] * 16+
+	[Trace(['a','b','d','z','f','z','z','z','h','i','j'])] * 16+
+	[Trace(['a','b','d','z','f','z','h','e','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','c','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','c','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','c','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','c','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','c','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','c','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','z','c','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','z','c','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','z','c','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','z','c','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','i','z','z','z','z','h','j'])] * 16+
+	[Trace(['a','b','d','f','e','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','e','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','f','e','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','e','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','f','e','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','e','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','e','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','f','e','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','f','e','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','z','i','z','z','z','h','j'])] * 16+
+	[Trace(['a','b','d','f','z','e','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','z','e','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','z','e','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','f','z','e','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','f','z','e','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','z','e','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','z','z','i','z','z','h','j'])] * 16+
+	[Trace(['a','b','d','f','z','z','e','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','f','z','z','e','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','f','z','z','e','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','f','z','z','z','i','z','h','j'])] * 16+
+	[Trace(['a','b','d','f','z','z','z','z','i','h','j'])] * 16+
+	[Trace(['a','b','d','f','z','z','z','z','h','i','j'])] * 16+
+	[Trace(['a','b','d','f','z','z','h','e','f','i','j'])] * 4+
+	[Trace(['a','b','d','f','h','e','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','f','h','e','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','h','f','e','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','h','f','e','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','h','c','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','h','c','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','z','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','b','d','c','z','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','c','z','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','c','z','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','c','z','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','c','z','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','c','z','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','c','z','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','c','z','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','c','z','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','c','h','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','h','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','b','d','c','b','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','b','d','c','b','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','b','d','c','b','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','c','b','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','c','b','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','c','b','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','b','d','c','b','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','c','b','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','b','d','c','b','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','b','d','c','b','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','b','d','c','b','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','b','d','c','b','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','b','d','c','b','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','d','z','z','z','z','h','b','f','i','j'])] * 16+
+	[Trace(['a','d','z','z','z','z','b','f','i','h','j'])] * 16+
+	[Trace(['a','d','z','z','z','z','b','f','h','i','j'])] * 16+
+	[Trace(['a','d','z','z','z','z','b','h','f','i','j'])] * 16+
+	[Trace(['a','d','z','z','z','b','z','f','i','h','j'])] * 16+
+	[Trace(['a','d','z','z','z','b','z','f','h','i','j'])] * 16+
+	[Trace(['a','d','z','z','z','b','z','h','f','i','j'])] * 16+
+	[Trace(['a','d','z','z','z','b','f','i','z','h','j'])] * 16+
+	[Trace(['a','d','z','z','z','b','f','z','i','h','j'])] * 16+
+	[Trace(['a','d','z','z','z','b','f','z','h','i','j'])] * 16+
+	[Trace(['a','d','z','z','h','b','f','e','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','h','b','c','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','z','z','f','i','h','j'])] * 16+
+	[Trace(['a','d','z','z','b','z','z','f','h','i','j'])] * 16+
+	[Trace(['a','d','z','z','b','z','z','h','f','i','j'])] * 16+
+	[Trace(['a','d','z','z','b','z','f','i','z','h','j'])] * 16+
+	[Trace(['a','d','z','z','b','z','f','z','i','h','j'])] * 16+
+	[Trace(['a','d','z','z','b','z','f','z','h','i','j'])] * 16+
+	[Trace(['a','d','z','z','b','f','i','z','z','h','j'])] * 16+
+	[Trace(['a','d','z','z','b','f','e','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','z','b','f','e','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','f','e','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','f','z','i','z','h','j'])] * 16+
+	[Trace(['a','d','z','z','b','f','z','z','i','h','j'])] * 16+
+	[Trace(['a','d','z','z','b','f','z','z','h','i','j'])] * 16+
+	[Trace(['a','d','z','z','b','f','h','e','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','h','f','e','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','h','c','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','c','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','c','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','z','b','c','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','z','b','c','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','z','z','f','i','h','j'])] * 16+
+	[Trace(['a','d','z','b','z','z','z','f','h','i','j'])] * 16+
+	[Trace(['a','d','z','b','z','z','z','h','f','i','j'])] * 16+
+	[Trace(['a','d','z','b','z','z','f','i','z','h','j'])] * 16+
+	[Trace(['a','d','z','b','z','z','f','z','i','h','j'])] * 16+
+	[Trace(['a','d','z','b','z','z','f','z','h','i','j'])] * 16+
+	[Trace(['a','d','z','b','z','f','i','z','z','h','j'])] * 16+
+	[Trace(['a','d','z','b','z','f','e','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','z','f','e','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','f','e','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','f','z','i','z','h','j'])] * 16+
+	[Trace(['a','d','z','b','z','f','z','z','i','h','j'])] * 16+
+	[Trace(['a','d','z','b','z','f','z','z','h','i','j'])] * 16+
+	[Trace(['a','d','z','b','z','f','h','e','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','h','f','e','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','h','c','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','c','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','c','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','z','c','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','z','c','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','i','z','z','z','h','j'])] * 16+
+	[Trace(['a','d','z','b','f','e','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','f','e','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','e','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','e','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','z','b','f','e','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','f','e','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','z','i','z','z','h','j'])] * 16+
+	[Trace(['a','d','z','b','f','z','e','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','f','z','e','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','z','e','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','f','z','z','i','z','h','j'])] * 16+
+	[Trace(['a','d','z','b','f','z','z','z','i','h','j'])] * 16+
+	[Trace(['a','d','z','b','f','z','z','z','h','i','j'])] * 16+
+	[Trace(['a','d','z','b','f','z','h','e','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','c','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','c','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','c','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','c','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','c','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','c','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','z','b','c','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','z','b','c','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','z','b','c','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','z','b','c','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','h','b','f','e','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','h','b','f','e','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','h','b','c','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','h','b','c','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','z','z','z','z','f','i','h','j'])] * 16+
+	[Trace(['a','d','b','z','z','z','z','f','h','i','j'])] * 16+
+	[Trace(['a','d','b','z','z','z','z','h','f','i','j'])] * 16+
+	[Trace(['a','d','b','z','z','z','f','i','z','h','j'])] * 16+
+	[Trace(['a','d','b','z','z','z','f','z','i','h','j'])] * 16+
+	[Trace(['a','d','b','z','z','z','f','z','h','i','j'])] * 16+
+	[Trace(['a','d','b','z','z','f','i','z','z','h','j'])] * 16+
+	[Trace(['a','d','b','z','z','f','e','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','z','f','e','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','f','e','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','f','z','i','z','h','j'])] * 16+
+	[Trace(['a','d','b','z','z','f','z','z','i','h','j'])] * 16+
+	[Trace(['a','d','b','z','z','f','z','z','h','i','j'])] * 16+
+	[Trace(['a','d','b','z','z','f','h','e','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','h','f','e','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','h','c','b','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','c','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','c','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','z','c','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','z','c','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','i','z','z','z','h','j'])] * 16+
+	[Trace(['a','d','b','z','f','e','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','f','e','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','e','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','e','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','z','f','e','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','f','e','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','z','i','z','z','h','j'])] * 16+
+	[Trace(['a','d','b','z','f','z','e','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','f','z','e','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','z','e','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','f','z','z','i','z','h','j'])] * 16+
+	[Trace(['a','d','b','z','f','z','z','z','i','h','j'])] * 16+
+	[Trace(['a','d','b','z','f','z','z','z','h','i','j'])] * 16+
+	[Trace(['a','d','b','z','f','z','h','e','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','c','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','c','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','c','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','c','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','c','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','c','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','z','c','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','z','c','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','z','c','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','z','c','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','i','z','z','z','z','h','j'])] * 16+
+	[Trace(['a','d','b','f','e','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','e','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','f','e','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','e','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','f','e','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','e','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','e','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','f','e','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','f','e','c','b','h','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','z','i','z','z','z','h','j'])] * 16+
+	[Trace(['a','d','b','f','z','e','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','z','e','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','z','e','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','f','z','e','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','f','z','e','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','z','e','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','z','z','i','z','z','h','j'])] * 16+
+	[Trace(['a','d','b','f','z','z','e','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','f','z','z','e','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','f','z','z','e','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','f','z','z','z','i','z','h','j'])] * 16+
+	[Trace(['a','d','b','f','z','z','z','z','i','h','j'])] * 16+
+	[Trace(['a','d','b','f','z','z','z','z','h','i','j'])] * 16+
+	[Trace(['a','d','b','f','z','z','h','e','f','i','j'])] * 4+
+	[Trace(['a','d','b','f','h','e','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','f','h','e','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','h','f','e','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','h','f','e','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','h','c','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','h','c','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','z','z','h','b','f','i','j'])] * 4+
+	[Trace(['a','d','b','c','z','z','b','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','c','z','z','b','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','c','z','z','b','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','c','z','b','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','c','z','b','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','c','z','b','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','c','z','b','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','c','z','b','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','c','z','b','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','c','h','b','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','h','b','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','z','z','f','i','h','j'])] * 4+
+	[Trace(['a','d','b','c','b','z','z','f','h','i','j'])] * 4+
+	[Trace(['a','d','b','c','b','z','z','h','f','i','j'])] * 4+
+	[Trace(['a','d','b','c','b','z','f','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','c','b','z','f','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','c','b','z','f','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','c','b','f','i','z','z','h','j'])] * 4+
+	[Trace(['a','d','b','c','b','f','e','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','c','b','f','e','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','f','e','h','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','f','z','i','z','h','j'])] * 4+
+	[Trace(['a','d','b','c','b','f','z','z','i','h','j'])] * 4+
+	[Trace(['a','d','b','c','b','f','z','z','h','i','j'])] * 4+
+	[Trace(['a','d','b','c','b','f','h','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','h','f','e','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','h','c','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','c','h','b','f','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','c','b','f','i','h','j'])] * 1+
+	[Trace(['a','d','b','c','b','c','b','f','h','i','j'])] * 1+
+	[Trace(['a','d','b','c','b','c','b','h','f','i','j'])] * 1
+) 
+alpha_plus_lpn_5 = LabelledPetriNet(
+        places=[
+                Place("P_sink",pid="dbdd0237-8ad1-41e6-8304-b936ae99afd0"),
+                Place("P_({'f'},{'e', 'i'})",pid="5e406806-d04f-4d26-92b4-c600bee51343"),
+                Place("P_({'b', 'e'},{'c', 'f'})",pid="2291bfce-d341-4fa8-bb14-a88d09a95a5c"),      
+                Place("P_({'h'},{'j'})",pid="af98d503-9569-4022-8009-3096c1e68829"),
+                Place("P_({'a', 'c'},{'b'})",pid="8f801b01-51a2-4070-9aef-f5eb657a40b0"),
+                Place("P_({'a'},{'d'})",pid="a557921f-68f9-4f14-9a54-08b2168b75bb"),
+                Place("P_({'d'},{'h'})",pid="4302656f-be39-4eb7-8796-36a990f6edf8"),
+                Place("P_({'i'},{'j'})",pid="549d1720-266c-488e-abce-b4d3b295ad51"),
+                Place("P_initial",pid="233785f2-d1f7-4ca5-98b9-ec763b64e15d"),
+        ],
+        transitions=[
+                Transition("a",tid="beac9b42-59a7-4ff6-8108-dce47d036881",weight=1.0,silent=False), 
+                Transition("c",tid="631534d2-7226-47ed-a9be-d753b22a1981",weight=1.0,silent=False), 
+                Transition("b",tid="a91aa8e9-1ade-4186-9a21-226b0d69b2c6",weight=1.0,silent=False), 
+                Transition("j",tid="b15fa8ea-71a9-4a27-8253-2717d2bf3fa9",weight=1.0,silent=False), 
+                Transition("d",tid="2821344a-cd9e-4ca9-a858-3642b8b34607",weight=1.0,silent=False), 
+                Transition("h",tid="267669ee-59a7-4857-8b02-0427a6c166b6",weight=1.0,silent=False), 
+                Transition("z",tid="ef2278f3-c3ea-4430-b339-555d9b96767c",weight=1.0,silent=False), 
+                Transition("i",tid="8b1a4029-1c1b-4f6b-9c0e-bee77c5fe141",weight=1.0,silent=False), 
+                Transition("f",tid="91a41ea3-9f17-49d7-8133-6d87cbc9a644",weight=1.0,silent=False), 
+                Transition("e",tid="46067b76-4630-4594-bf26-3c19ac2df923",weight=1.0,silent=False), 
+        ],
+        arcs=[
+                Arc(from_node=Transition("a",tid="beac9b42-59a7-4ff6-8108-dce47d036881",weight=1.0,silent=False),to_node=Place("P_({'a'},{'d'})",pid="a557921f-68f9-4f14-9a54-08b2168b75bb")),
+                Arc(from_node=Place("P_({'d'},{'h'})",pid="4302656f-be39-4eb7-8796-36a990f6edf8"),to_node=Transition("z",tid="ef2278f3-c3ea-4430-b339-555d9b96767c",weight=1.0,silent=False)),
+                Arc(from_node=Transition("j",tid="b15fa8ea-71a9-4a27-8253-2717d2bf3fa9",weight=1.0,silent=False),to_node=Place("P_sink",pid="dbdd0237-8ad1-41e6-8304-b936ae99afd0")),
+                Arc(from_node=Place("P_({'a'},{'d'})",pid="a557921f-68f9-4f14-9a54-08b2168b75bb"),to_node=Transition("d",tid="2821344a-cd9e-4ca9-a858-3642b8b34607",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'i'},{'j'})",pid="549d1720-266c-488e-abce-b4d3b295ad51"),to_node=Transition("j",tid="b15fa8ea-71a9-4a27-8253-2717d2bf3fa9",weight=1.0,silent=False)),
+                Arc(from_node=Transition("i",tid="8b1a4029-1c1b-4f6b-9c0e-bee77c5fe141",weight=1.0,silent=False),to_node=Place("P_({'i'},{'j'})",pid="549d1720-266c-488e-abce-b4d3b295ad51")),
+                Arc(from_node=Place("P_({'f'},{'e', 'i'})",pid="5e406806-d04f-4d26-92b4-c600bee51343"),to_node=Transition("e",tid="46067b76-4630-4594-bf26-3c19ac2df923",weight=1.0,silent=False)),     
+                Arc(from_node=Transition("e",tid="46067b76-4630-4594-bf26-3c19ac2df923",weight=1.0,silent=False),to_node=Place("P_({'b', 'e'},{'c', 'f'})",pid="2291bfce-d341-4fa8-bb14-a88d09a95a5c")),
+                Arc(from_node=Transition("z",tid="ef2278f3-c3ea-4430-b339-555d9b96767c",weight=1.0,silent=False),to_node=Place("P_({'d'},{'h'})",pid="4302656f-be39-4eb7-8796-36a990f6edf8")),
+                Arc(from_node=Place("P_initial",pid="233785f2-d1f7-4ca5-98b9-ec763b64e15d"),to_node=Transition("a",tid="beac9b42-59a7-4ff6-8108-dce47d036881",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'h'},{'j'})",pid="af98d503-9569-4022-8009-3096c1e68829"),to_node=Transition("j",tid="b15fa8ea-71a9-4a27-8253-2717d2bf3fa9",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'d'},{'h'})",pid="4302656f-be39-4eb7-8796-36a990f6edf8"),to_node=Transition("h",tid="267669ee-59a7-4857-8b02-0427a6c166b6",weight=1.0,silent=False)),
+                Arc(from_node=Transition("f",tid="91a41ea3-9f17-49d7-8133-6d87cbc9a644",weight=1.0,silent=False),to_node=Place("P_({'f'},{'e', 'i'})",pid="5e406806-d04f-4d26-92b4-c600bee51343")),     
+                Arc(from_node=Place("P_({'a', 'c'},{'b'})",pid="8f801b01-51a2-4070-9aef-f5eb657a40b0"),to_node=Transition("b",tid="a91aa8e9-1ade-4186-9a21-226b0d69b2c6",weight=1.0,silent=False)),     
+                Arc(from_node=Transition("b",tid="a91aa8e9-1ade-4186-9a21-226b0d69b2c6",weight=1.0,silent=False),to_node=Place("P_({'b', 'e'},{'c', 'f'})",pid="2291bfce-d341-4fa8-bb14-a88d09a95a5c")),
+                Arc(from_node=Place("P_({'b', 'e'},{'c', 'f'})",pid="2291bfce-d341-4fa8-bb14-a88d09a95a5c"),to_node=Transition("c",tid="631534d2-7226-47ed-a9be-d753b22a1981",weight=1.0,silent=False)),
+                Arc(from_node=Place("P_({'f'},{'e', 'i'})",pid="5e406806-d04f-4d26-92b4-c600bee51343"),to_node=Transition("i",tid="8b1a4029-1c1b-4f6b-9c0e-bee77c5fe141",weight=1.0,silent=False)),     
+                Arc(from_node=Transition("a",tid="beac9b42-59a7-4ff6-8108-dce47d036881",weight=1.0,silent=False),to_node=Place("P_({'a', 'c'},{'b'})",pid="8f801b01-51a2-4070-9aef-f5eb657a40b0")),     
+                Arc(from_node=Transition("c",tid="631534d2-7226-47ed-a9be-d753b22a1981",weight=1.0,silent=False),to_node=Place("P_({'a', 'c'},{'b'})",pid="8f801b01-51a2-4070-9aef-f5eb657a40b0")),     
+                Arc(from_node=Transition("d",tid="2821344a-cd9e-4ca9-a858-3642b8b34607",weight=1.0,silent=False),to_node=Place("P_({'d'},{'h'})",pid="4302656f-be39-4eb7-8796-36a990f6edf8")),
+                Arc(from_node=Place("P_({'b', 'e'},{'c', 'f'})",pid="2291bfce-d341-4fa8-bb14-a88d09a95a5c"),to_node=Transition("f",tid="91a41ea3-9f17-49d7-8133-6d87cbc9a644",weight=1.0,silent=False)),
+                Arc(from_node=Transition("h",tid="267669ee-59a7-4857-8b02-0427a6c166b6",weight=1.0,silent=False),to_node=Place("P_({'h'},{'j'})",pid="af98d503-9569-4022-8009-3096c1e68829")),
+        ],
+        name='Petri net'
+)
+
+class SingleThreadAlphaPlusTest(unittest.TestCase):
+    """
+    The alpha-plus miner is equivalent to the alpla miner when given an 
+    event log without one-length or two-length loops.
+    """
+
+    def weakly_compare(self, disc:LabelledPetriNet, expect:LabelledPetriNet):
+        # weakly test that two nets are equivalent
+        for p in disc.places:
+            found_match = False
+            for o in expect.places:
+                if p.name == o.name:
+                    found_match = True
+                    break
+            self.assertTrue(found_match, 
+                f"Place ({p}) not found in expected places :\n{expect.places}")
+        for t in disc.transitions:
+            found_match = False
+            for o in expect.transitions:
+                if t.name == t.name:
+                    found_match = True
+                    break
+            self.assertTrue(found_match, 
+                f"Transition ({t}) not found in expected transitions :\n{expect.transitions}")
+        for a in disc.arcs:
+            found_match = False
+            for o in expect.arcs:
+                if o.from_node.name == a.from_node.name and o.to_node.name == a.to_node.name:
+                    found_match = True
+                    break
+            self.assertTrue(found_match, 
+                f"Arc ({a}) not found in expected arcs :\n{expect.arcs}")
+
+    def setUp(self):
+        self.miner = AlphaMinerPlusInstance()
+
+    def test_creation(self):
+        miner = AlphaMinerPlusInstance(min_inst=5)
+        miner = AlphaMinerPlusInstance()
+        miner = deepcopy(miner)
+
+    def test_footprint_matrix(self):
+        miner = self.miner
+        matrix = miner.mine_footprint_matrix(LOG)
+        # test that footprint matrix has the right follows
+        # test that footprint matrix has the right relations
+        for col in ACTS:
+            for row in ACTS:
+                crelation = matrix[col][row]
+                rrelation = MATRIX[col][row]
+                # test one
+                self.assertEqual(crelation._follows, 
+                    rrelation._follows,
+                    "computed and expected follows differ :: "+
+                    f"{crelation._follows} vs {rrelation._follows}"
+                )
+                # test two
+                self.assertEqual(crelation.relation(), 
+                    rrelation.relation(),
+                    "computed and expected alpha relation differ :: "+
+                    f"{crelation} vs {rrelation}"
+                )
+
+    def test_mine(self):
+        miner = self.miner
+        # following p173 and L5 in Process Mining (2016;2ND ED) 
+        net = miner.discover(BOOK_LOG)
+        for p in net.places:
+            found_match = False
+            for o in BOOK_LPN_PL:
+                if p.name == o.name:
+                    found_match = True
+                    break
+            self.assertTrue(found_match, 
+                f"Place ({p}) not found in expected places :\n{BOOK_LPN_PL}")
+        for t in net.transitions:
+            found_match = False
+            for o in BOOK_LPN_TL:
+                if t.name == t.name:
+                    found_match = True
+                    break
+            self.assertTrue(found_match, 
+                f"Transition ({t}) not found in expected transitions :\n{BOOK_LPN_TL}")
+        for a in net.arcs:
+            found_match = False
+            for o in BOOK_LPN_FL:
+                if o.from_node.name == a.from_node.name and o.to_node.name == a.to_node.name:
+                    found_match = True
+                    break
+            self.assertTrue(found_match, 
+                f"Arc ({a}) not found in expected arcs :\n{BOOK_LPN_FL}")
+
+
+    def test_paper_example_1(self):
+        miner = self.miner
+        # following figure 2, the alpha+ miner should return the original
+        # Petri net
+        net = miner.discover(alpha_plus_log_1)
+        # weakly test that two nets are equivalent
+        self.weakly_compare(net, alpha_plus_lpn_1)
+
+    def test_paper_example_2(self):
+        miner = self.miner
+        # following figure 5, the alpha+ miner should return the original
+        # Petri net
+        net = miner.discover(alpha_plus_log_2)
+        # weakly test that two nets are equivalent
+        self.weakly_compare(net, alpha_plus_lpn_2)
+
+    def test_paper_example_3(self):
+        miner = self.miner
+        # following figure 5, the alpha+ miner should return the original
+        # Petri net
+        net = miner.discover(alpha_plus_log_3)
+        # weakly test that two nets are equivalent
+        self.weakly_compare(net, alpha_plus_lpn_3)
+
+    def test_paper_example_4(self):
+        miner = self.miner
+        # following figure 5, the alpha+ miner should return the original
+        # Petri net
+        net = miner.discover(alpha_plus_log_4)
+        # weakly test that two nets are equivalent
+        self.weakly_compare(net, alpha_plus_lpn_4)
+
+    def test_paper_example_5(self):
+        miner = self.miner
+        # following figure 5, the alpha+ miner should return the original
+        # Petri net
+        net = miner.discover(alpha_plus_log_5)
+        # weakly test that two nets are equivalent
+        self.weakly_compare(net, alpha_plus_lpn_5)
+
+class OptimisedAlphaPlusTest(SingleThreadAlphaPlusTest):
+    """
+    Reuse the tests from SingleThreadAlphaTest to test that the optimised
+    version returns the same results.
+    """
+
+    def setUp(self):
+        from pmkoalas._logging import setLevel
+        from logging import INFO
+        self.miner = AlphaMinerPlusInstance(optimised=True)
+
+    def tearDown(self) -> None:
+        from pmkoalas._logging import setLevel
+        from logging import ERROR
+        setLevel(ERROR)

--- a/tests/models/test_petrinet.py
+++ b/tests/models/test_petrinet.py
@@ -30,7 +30,7 @@ expectedXML = '''<pnml>
           <text>I</text>
         </name>
       </place>
-      <transition id="transition-2">
+      <transition id="transition-2" invisible="true">
         <name>
           <text>tau</text>
         </name>


### PR DESCRIPTION
The PR adds the following:

- Adds the alpha+ discovery technique 
- Adds a pettier dot form
  - Still need to touch up the form a bit.
- Adds a helper to generate runs of a LPN

The discovery and helper to generate runs both have test cases implemented. Unsure if the dot conversion needs one, maybe one to ensure that it runs?

The new dotform for LPNs when visualised by dot produces the following:
![roadfines-alpha-plus](https://github.com/user-attachments/assets/5bde66a7-9d6d-4a66-9402-33a959a3f91a)
