### PR TITLE
Utility for quickly creating an XES file

### DIFF
--- a/pmkoalas/export.py
+++ b/pmkoalas/export.py
@@ -46,11 +46,6 @@ def export_to_xes_simple(filepath:str, log:EventLog) -> None:
 
     info(f"exporting log of size :: {len(log)}")
 
-    # check filepath
-    if (not os.path.exists(os.path.dirname(filepath))):
-        os.makedirs(os.path.dirname(filepath),exist_ok=True)
-
-        info(f"made directory for :: {filepath}")
 
     with open(filepath,"wb") as flog:
         # add log element
@@ -152,12 +147,6 @@ def export_to_xes_complex(filepath:str, log:ComplexEventLog) -> None:
         raise ValueError(f"Was expecting a complex event log, but was given :: {type(log)}")
 
     info(f"exporting log of size :: {len(log)}")
-
-    # check filepath
-    if (not os.path.exists(os.path.dirname(filepath))):
-        os.makedirs(os.path.dirname(filepath),exist_ok=True)
-
-        info(f"made directory for :: {filepath}")
 
     with open(filepath,"wb") as flog:
         # add log element

--- a/pmkoalas/quicklog.py
+++ b/pmkoalas/quicklog.py
@@ -11,7 +11,7 @@ from pmkoalas import dtlog, export
 def traces_to_xes(traces,log_fname):
     log = dtlog.convert( *traces) 
     export.export_to_xes_simple( log_fname, log )
-    print(f'Wrote {len(traces)} to {log_fname}')
+    print(f'Wrote {len(traces)} traces to {log_fname}')
 
 
 DESCRIPTION = \

--- a/pmkoalas/quicklog.py
+++ b/pmkoalas/quicklog.py
@@ -1,0 +1,42 @@
+"""
+Command line tool to quickly create an XES log from arguments.
+"""
+
+
+import argparse
+
+from pmkoalas import dtlog, export
+
+
+def traces_to_xes(traces,log_fname):
+    log = dtlog.convert( *traces) 
+    export.export_to_xes_simple( log_fname, log )
+    print(f'Wrote {len(traces)} to {log_fname}')
+
+
+DESCRIPTION = \
+"""
+Output delimited input traces to an XES log.
+
+Delimited traces are defined by the koalas.dtlog module.
+"""
+
+EPILOG = \
+"""
+Example use:
+
+%(prog)s \"a b c\" \"a d c\" -f choice.xes
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser( description=DESCRIPTION, epilog=EPILOG)
+    parser.add_argument('-f','--file',default='out.xes', 
+                        help="Name of the output XES file" )
+    parser.add_argument('traces', nargs='+')
+    args = parser.parse_args()
+    traces_to_xes( args.traces, args.file )
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This patch also fixes a bug where exporting an XES file in the current directory will throw an exception. It fixes it by removing the subdirectory auto-creation, which breaks longstanding Unix conventions, and is a bit rude.